### PR TITLE
Add geckodriver logs and virtualenv folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #python
 __pycache__
 *.pyc
+venv/
 
 #robot
 *.html
@@ -9,6 +10,7 @@ robot/*
 *.jpg
 *.png
 *.xml
+geckodriver-*.log
 
 #OS
 


### PR DESCRIPTION
While setting up I noticed these could be added to .gitignore. Not sure if `venv/` is necessary as people might use different names for the virtualenv folder but it could be useful as it's quite common.