### PR TITLE
shell scripts now throw no warning when there is a space in a path

### DIFF
--- a/00-verify_setup.sh
+++ b/00-verify_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/verify_env.py
 else
     python setup/verify_env.py

--- a/01-manual_testing.sh
+++ b/01-manual_testing.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/01-manual_testing.py
 else
     python setup/01-manual_testing.py

--- a/02-robot_syntax.sh
+++ b/02-robot_syntax.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/02-robot_syntax.py
 else
     python setup/01-robot_syntax.py

--- a/03-keywords_and_variables.sh
+++ b/03-keywords_and_variables.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/03-keywords_and_variables.py
 else
     python setup/03-keywords_and_variables.py

--- a/04-setups_and_teardowns.sh
+++ b/04-setups_and_teardowns.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/04-setups_and_teardowns.py
 else
     python setup/04-setups_and_teardowns.py

--- a/05-negative_testing.sh
+++ b/05-negative_testing.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/05-negative_testing.py
 else
     python setup/05-negative_testing.py

--- a/06-resource_files.sh
+++ b/06-resource_files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/06-resource_files.py
 else
     python setup/06-resource_files.py

--- a/07-test_template.sh
+++ b/07-test_template.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -x `which python3` ]; then
+if [ -x "`which python3`" ]; then
     python3 setup/07-test_template.py
 else
     python setup/07-test_template.py


### PR DESCRIPTION
When the path to python contains spaces, the shell scripts throw an error.
E.g., $ ./07-test_template.sh
./07-test_template.sh: line 2: [: too many arguments
Enclosing `which python` in quotation marks fixes this issue. 