### PR TITLE
Update the training to use Browser instead of SeleniumLibrary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ that we're going to need to have the following items installed:
 - Pip for Python 3
   - Windows: https://www.howtogeek.com/197947/how-to-install-python-on-windows/
   - Linux: `sudo apt-get install python3-pip && pip3 install --upgrade pip`
-  - MacOS: `brew install python` pip is already included
-- Node.js: https://nodejs.org/en/download/
+  - macOS: `brew install python` pip is already included
+- Node.js (version 12 or newer): https://nodejs.org/en/download/
 - System under test
   - Open a new terminal window, change directory to this repository root folder and run the application
     with: `python server/server.py`

--- a/README.md
+++ b/README.md
@@ -2,42 +2,31 @@
 
 ## Requirements
 
-In this series of exercises we're going to run several automated tests against web application. To do that we're going to need to have the following items installed:
+In this series of exercises we're going to run several automated tests against web application. To do
+that we're going to need to have the following items installed:
 
-- Python 3: https://www.python.org/downloads/
+- Python (version 3.7 or newer): https://www.python.org/downloads/
   - Remember to add Python folder to PATH environment variable.
 - Pip for Python 3
   - Windows: https://www.howtogeek.com/197947/how-to-install-python-on-windows/
   - Linux: `sudo apt-get install python3-pip && pip3 install --upgrade pip`
   - MacOS: `brew install python` pip is already included
-- Browser
-  - Chrome and chromedriver: https://chromedriver.chromium.org/downloads
-  - Or Firefox and geckodriver: https://github.com/mozilla/geckodriver/releases
+- Node.js: https://nodejs.org/en/download/
 - System under test
-    - Open a new terminal window, change directory to this repository root folder and run the application with:
-       -  `python server/server.py`
+  - Open a new terminal window, change directory to this repository root folder and run the application
+    with: `python server/server.py`
 
-Recommendations:
-  - In order to make installing with pip easier, use virtualenv (https://virtualenv.pypa.io/en/latest/)
-    - Short instruction to virtualenv use
-    ```
+### Recommended
+
+- In order to make installing with pip easier, use virtualenv (https://virtualenv.pypa.io/en/latest/)
+  - Short instruction to virtualenv use
+
+    ```shell
     pip install virtualenv --user
     virtualenv <choose_a_folder_name>
-    source <chosen_folder_name>/bin/activate`
+    source <chosen_folder_name>/bin/activate
     ```
-  - use webdrivermanager to manage browser drivers
-    ```
-    pip install webdrivermanager
-    webdrivermanager firefox
-    webdrivermanager chrome
-    ```
-    
-Protip (if not using webdrivermanager): Add the chromedriver or geckodriver (after download) to a location that is in PATH environment variable. To see what folders are included you can use
-  - MacOS/Linux: in terminal run command: `echo $PATH`
-  - Windows:
-    - in Command Prompt run command: `echo %PATH`
-    - in PowerShell run command: `echo $env:path`
 
 ## Get started
 
-After you have installed the requirements check the [Getting started exercise](exercises/00-getting-started.md) and proceed with the exercises
+After you have installed the requirements check the [Getting started exercise](exercises/00-getting-started.md) and proceed with the exercises.

--- a/exercises/00-getting-started.md
+++ b/exercises/00-getting-started.md
@@ -17,7 +17,7 @@ used frequently in this ecosystem.
 - *keyword* - a component, similar to a function in programming, that robot uses to execute steps
 - *arguments* - Values that are given to keywords. Also known as parameters.
 
-## Install robotframework
+## Install Robot Framework
 
 In order to run Robot Framework test cases we're going to need install Robot Framework. We install this by
 using `pip`. By default, the installation happens by calling `pip3 install <package_name>`, but if you are
@@ -27,7 +27,7 @@ Install Robot Framework: `pip3 install robotframework`.
 
 If the installation was successful, you can use `robot -h` command to verify that you get command line
 help for Robot Framework. Output should include Robot version number and some other helpful stuff,
-includin the command line options (which are also available in [here](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options)).
+including the command line options (which are also available in [here](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options)).
 
 To run automated test cases for web UIs, the current go-to library is the Browser-library.
 
@@ -54,9 +54,9 @@ After the server has started it will be running in http://localhost:7272.
 Verify setup by running:
 
 - in Windows: double click 00-verify_setup.cmd
-- in MacOS/Linux: run command `./exercises/verify/00-verify_setup.sh`
+- in macOS/Linux: run command `./exercises/verify/00-verify_setup.sh`
 
 This should take a few seconds. If the output of the script ends with `Setup in perfect condition!`
 we're good to go.
 
-Otherwise, check the output and fix the missing packages or place the webdriver in the correct location.
+Otherwise, check the output and fix the missing packages.

--- a/exercises/00-getting-started.md
+++ b/exercises/00-getting-started.md
@@ -1,10 +1,13 @@
 # Getting started
 
-In this section we will install Robot Framework, needed test libraries and ensure that the environment is up and running in order to do web UI testing with Robot Framework.
+In this section we will install Robot Framework, needed test libraries and ensure that the environment
+is up and running in order to do web UI testing with Robot Framework.
 
 ## Terminology
 
-In this section, you will see a lot of Python, operating system and Robot Framework related jargon which might be confusing to some. So before you go further, let's clarify some terminology that is used frequently in this ecosystem.
+In this section, you will see a lot of Python, operating system and Robot Framework related jargon
+which might be confusing to some. So before you go further, let's clarify some terminology that is
+used frequently in this ecosystem.
 
 - *pip* - Python package manager, this is a tool that is needed to install Robot Framework and needed test libraries
 - *shell* - The shell is the command interpreter in an operating system such as Unix or GNU/Linux, it is a program that executes other programs
@@ -18,20 +21,22 @@ In this section, you will see a lot of Python, operating system and Robot Framew
 
 In order to run Robot Framework test cases we're going to need install Robot Framework. We install this by
 using `pip`. By default, the installation happens by calling `pip3 install <package_name>`, but if you are
-using an older version of Python or a virtual environment, you can try `pip install <package_name>` instead.
+using a virtual environment, or have an alias defined, you can try `pip install <package_name>` instead.
 
 Install Robot Framework: `pip3 install robotframework`.
 
-If the installation was successful, you can use `robot -h` command to verify that you get command line help for Robot Framework.
+If the installation was successful, you can use `robot -h` command to verify that you get command line
+help for Robot Framework. Output should include Robot version number and some other helpful stuff,
+includin the command line options (which are also available in [here](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options)).
 
-Output should be something like this: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options
+To run automated test cases for web UIs, the current go-to library is the Browser-library.
 
-To run automated test cases for web UIs, the most popular test library is SeleniumLibrary.
+Install Browser: `pip3 install robotframework-browser`. After the installation has completed successfully,
+the library has to be initialized by running `rfbrowser init`.
 
-Install SeleniumLibrary: `pip3 install robotframework-seleniumlibrary`.
-
-In order to ensure that you've done exercises as expected we need you to install robotframework-lint tool. A linting
-tool is a lightweight static analysis tool to verify that you and your team are doing your code consistently.
+In order to ensure that you've done exercises as expected we need you to install robotframework-lint
+tool. A linting tool is a lightweight static analysis tool to verify that you and your team are doing
+your code consistently.
 
 Install Robot Framework linter: `pip3 install robotframework-lint`.
 
@@ -42,7 +47,7 @@ by running `python3 server/server.py` in your terminal/command prompt. Your term
 now occupied with running the server, which means you need to open another terminal/command prompt to run
 your tests.
 
-After the server has started it will be running in `localhost:7272`.
+After the server has started it will be running in http://localhost:7272.
 
 ## Verify installation
 
@@ -51,9 +56,7 @@ Verify setup by running:
 - in Windows: double click 00-verify_setup.cmd
 - in MacOS/Linux: run command `./exercises/verify/00-verify_setup.sh`
 
-You should see Firefox and/or Chrome open to the test server for a few seconds then close down. Don't
-worry if only one browser opens, it's enough for the purpose of this training.
-
-If the output of the script ends with: `Setup in perfect condition!` we're good to go.
+This should take a few seconds. If the output of the script ends with `Setup in perfect condition!`
+we're good to go.
 
 Otherwise, check the output and fix the missing packages or place the webdriver in the correct location.

--- a/exercises/01-manual_testing.md
+++ b/exercises/01-manual_testing.md
@@ -16,7 +16,7 @@ Features:
   - Password: mode
   - Submit login form button
 - After successful login the user is redirected to the welcome page
-  - User can logout after successful login and will be redirected to the login page
+  - User can log out after successful login and will be redirected to the login page
 - After incorrect login credentials the user is redirected to the error page
 
 ## Exercise 1
@@ -24,7 +24,7 @@ Features:
 How would you test the successful login use case?
 
 In the root directory of the rf-katas project create a `robot` folder. Inside it add a text file, call
-it `login.robot` (note that .robot is the extension, not .txt).
+it `login.robot` (note that `.robot` is the extension, not `.txt`).
 
 Write line by line, all the steps that you would need to perform if you were manually testing the login feature.
 
@@ -35,4 +35,4 @@ After you've added steps that you think are needed to manually test login featur
 - Windows: double click `01-manual_testing.cmd`
 - Linux/macOS: `./exercises/verify/01-manual_testing.sh`
 
-If the output is `Ready to proceed!` then you're good to go! Otherwise the check the output about what is missing?
+If the output is `Ready to proceed!` then you're good to go! Otherwise, the check the output about what is missing?

--- a/exercises/01-manual_testing.md
+++ b/exercises/01-manual_testing.md
@@ -1,6 +1,7 @@
 # Manual testing
 
-Manual testing is usually a part of test automation. We need to know the steps that are then going to be automated.
+Manual testing is usually a part of test automation. We need to know the steps that are then going to
+be automated.
 
 Let us first go through our System Under Testing (SUT) before we proceed.
 
@@ -9,19 +10,21 @@ Let us first go through our System Under Testing (SUT) before we proceed.
 Our system under testing is simple web application that is running at localhost:7272 address.
 
 Features:
-  - index page contains login form
-    - username: demo
-    - password: mode
-    - submit login form button
-  - After successful login the user is redirected to the welcome page
-    - User can logout after successful login and will be redirected to the login page
-  - After incorrect login credentials the user is redirected to the error page
+
+- Index page contains login form
+  - Username: demo
+  - Password: mode
+  - Submit login form button
+- After successful login the user is redirected to the welcome page
+  - User can logout after successful login and will be redirected to the login page
+- After incorrect login credentials the user is redirected to the error page
 
 ## Exercise 1
 
 How would you test the successful login use case?
 
-In the root directory of the rf-katas project create a `robot` folder. Inside it add a text file, call it `login.robot` (note that .robot is the extension, not .txt).
+In the root directory of the rf-katas project create a `robot` folder. Inside it add a text file, call
+it `login.robot` (note that .robot is the extension, not .txt).
 
 Write line by line, all the steps that you would need to perform if you were manually testing the login feature.
 
@@ -29,7 +32,7 @@ Write line by line, all the steps that you would need to perform if you were man
 
 After you've added steps that you think are needed to manually test login feature run:
 
-  - Windows: double click `01-manual_testing.cmd`
-  - Linux/macOS: `./exercises/verify/01-manual_testing.sh`
+- Windows: double click `01-manual_testing.cmd`
+- Linux/macOS: `./exercises/verify/01-manual_testing.sh`
 
-If the output is `Ready to proceed!` then you're good to go! Otherwise the check the output that what is missing?
+If the output is `Ready to proceed!` then you're good to go! Otherwise the check the output about what is missing?

--- a/exercises/02-robot-syntax.md
+++ b/exercises/02-robot-syntax.md
@@ -3,8 +3,8 @@
 <details>
     <summary>In the previous exercise we created <code>robot/login.robot</code> file and the content was most likely something like this</summary>
 
-```
-Open browser
+```text
+New page
 Navigate to localhost:7272
 Enter username
 Enter password
@@ -33,11 +33,11 @@ Each table starts with `***` and ends with `***`.
 
 There are 5 types of tables:
 
-  - `*** Settings ***` - to define libraries, resources, suite/test setups, documentation etc. http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-available-settings-in-test-data
-  - `*** Variables ***` - to define suite level variables http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#variable-section
-  - `*** Keywords ***` - user defined keywords http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-user-keywords
-  - `*** Test Cases ***` - All the suite (file) test cases goes below this one http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-case-syntax
-  - `*** Tasks ***` - http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-tasks
+- `*** Settings ***` - to define libraries, resources, suite/test setups, documentation etc. http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-available-settings-in-test-data
+- `*** Variables ***` - to define suite level variables http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#variable-section
+- `*** Keywords ***` - user defined keywords http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-user-keywords
+- `*** Test Cases ***` - All the suite (file) test cases goes below this one http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-case-syntax
+- `*** Tasks ***` - http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-tasks
 
 Check the Robot Framework syntax guide for more details: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-data-syntax
 
@@ -48,11 +48,11 @@ Once you've added the test case table let's run the command `robot robot/login.r
 
 Using the snippet from earlier we should get output:
 
-```
+```text
 ==============================================================================
 Login
 ==============================================================================
-Open browser                                                          | FAIL |
+New page                                                              | FAIL |
 Test case contains no keywords.
 ------------------------------------------------------------------------------
 Navigate to localhost:7272                                            | FAIL |
@@ -80,37 +80,38 @@ considered as a new test case.
 
 In order to make Robot understand that want to have 1 test case with 6 steps we need to define it like this:
 
-```
+```robot
 *** Test Cases ***
 
 Welcome Page Should Be Visible After Successful Login
 ```
 
-Now in order to have the `Open browser` we need to define it under the test case and in robot that is done with 4 spaces.
+Now in order to have the `New Page` we need to define it under the test case and in robot that is done with 4 spaces.
 
-Note that keywords are actually case-insensitive, so `open browser`, `OPEN BROWSER`, `Open browser`,
-and `OpEn BrOwSeR` will all work. However, the recommended way is to capitalize the first letter of
-each word, like `Open Browser` in this case.
+Note that keywords are actually case-insensitive, so `new page`, `NEW PAGE`, `New page`,
+and `NeW pAgE` will all work. However, the recommended way is to capitalize the first letter of
+each word, like `New Page` in this case.
 
-```
+```robot
 *** Test Cases ***
 
 Welcome Page Should Be Visible After Successful Login
-    Open Browser
+    New Page
 ```
 
-With 4 spaces at the beginning of the line indicates to robot that this keyword belongs to test case or keyword depending on the table that was defined.
+With 4 spaces at the beginning of the line indicates to robot that this keyword belongs to test case
+or keyword depending on the table that was defined.
 
 Now add all missing keywords as test step to our `Welcome Page Should Be Visible After Successful Login`
 
 After that run `robot robot/login.robot` and the output should be something like this:
 
-```
+```text
 ==============================================================================
 Login
 ==============================================================================
 Welcome Page Should Be Visible After Successful Login                 | FAIL |
-No keyword with name 'Open Browser' found.
+No keyword with name 'New Page' found.
 ------------------------------------------------------------------------------
 Login                                                                 | FAIL |
 1 critical test, 0 passed, 1 failed
@@ -120,26 +121,28 @@ Login                                                                 | FAIL |
 
 ## Test Libraries
 
-Robot now fails with `No keyword with name 'Open Browser' found.` but if we check the installed SeleniumLibrary documentation, we can see that there is in fact a keyword named `Open Browser`: https://robotframework.org/SeleniumLibrary/SeleniumLibrary.html#Open%20Browser
-_Why_ doesn't it show up?
+Robot now fails with `No keyword with name 'New Page' found.` but if we check the installed
+Browser-library's documentation, we can see that there is in fact a keyword named `New Page`:
+https://marketsquare.github.io/robotframework-browser/Browser.html#New%20Page. So _why_ doesn't
+it show up?
 
 This is because Robot Framework has built-in libraries that come along when you run `pip install robotframework` and
 will work "out of the box" without you having to worry about anything. However, most of the needed libraries (such as
-the SeleniumLibrary) are external libraries provided by the open source community and we need to tell Robot separately
+the Browser) are external and provided by the open source community. We need to tell Robot separately
 to use them.
 
 Check the library injection chapter from the user guide: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#importing-libraries
 
-So, in order to take SeleniumLibrary into use during runtime we need to add a `*** Settings ***` table and add
+So, in order to take Browser into use during runtime we need to add a `*** Settings ***` table and add
 the library definition there.
 
 After `Library` you need to have _at least_ 2 spaces (preferably 4) before defining the library name:
 `Library    SomeLibrary`.
 
-Once you've added the `Settings` table and told Robot to use SeleniumLibrary you can run `robot robot/login.robot`
+Once you've added the `Settings` table and told Robot to use Browser you can run `robot robot/login.robot`
 again and your output should be something like this:
 
-```
+```text
 ==============================================================================
 Login
 ==============================================================================
@@ -152,20 +155,59 @@ Login                                                                 | FAIL |
 ==============================================================================
 ```
 
-As the test starts, depending on the robotframework version, a default browser might open, but it will not show any page. This is because the keyword was called without arguments.
+As the test starts, the `No keyword with name 'New Page' found.` error does not pop up anymore. This
+means that opening a new page now works - or does it? Nothing seems to open. This is because the browser
+opens by default in a _headless_ state. Headless simply means that the GUI is not visible and the idea
+is to make test performance better. We need to open the browser specifically in a headful state if we
+want to see what is happening during the test.
 
-So now we need to add the necessary arguments for `Open Browser` keyword: https://robotframework.org/SeleniumLibrary/SeleniumLibrary.html#Open%20Browser
+Before getting into how to do that, let's expain three important Browser-library concepts: browser,
+context, and page.
+
+- _Browser_ indicates a browser - Chromium (Chrome, Edge, Opera), Firefox, or Webkit (Safari).
+- _Context_ includes cookies, sessions, profile settings etc. A context is opened within a browser.
+- _Page_ is simply a webpage (or a tab) which is opened inside a browser. A page is opened within a context.
+
+So when we call the `New Page` keyword without any context or browser created, what the keyword actually
+does is that it calls `New Browser` and `New Context` first. These calls are done with default settings.
+As it happens, a browser opens headless by default.
+
+If we want to open a browser in a headful state, we'll have to call the `New Browser` separately
+(before calling `New Page`) with a specific argument defining this: `headless=${FALSE}`. The context
+is still created with default arguments, and at this point there's no need to adjust those.
+
+*Pro tip:* as everything else, arguments can be specified by leaving at least 2 (preferably 4) spaces
+between the keyword and them.
+
+Running the tests headful is not necessary for the final test, but it makes debugging a lot easier
+as we then see what the tests are doing.
+
+So now the test case should look like something like below.
+
+```robot
+*** Test Cases ***
+
+Welcome Page Should Be Visible After Successful Login
+    New Browser    headless=${FALSE}
+    New Page
+```
+
+Now, after running the test yet again, a browser will open, but it won't show any page. This is because
+the keyword was called without arguments.
+
+So now we need to add the necessary arguments for `New Page` keyword: https://marketsquare.github.io/robotframework-browser/Browser.html#New%20Page.
 
 Our `robot/login.robot` file look now something like this (note that all words were capitalized as recommended):
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 
 *** Test Cases ***
 
 Welcome Page Should Be Visible After Successful Login
-    Open Browser    http://localhost:7272    browser=gc
+    New Browser    headless=${FALSE}
+    New Page    http://localhost:7272
     Navigate To localhost:7272
     Enter Username
     Enter Password
@@ -173,23 +215,26 @@ Welcome Page Should Be Visible After Successful Login
     Check That Welcome Page Text Is Visible
 ```
 
-Pro Tip 1: If you're using Firefox and geckodriver, replace `gc` with `ff` or `firefox`.
+*Note:* Make sure that the SUT is running on it's own windows and that you can access it with address
+http://localhost:7272.
 
-Pro Tip 2:  Make sure that the SUT is running on it's own windows and that you can access it with address http://localhost:7272
+Now you can see browser actually opening and accessing to SUT and then failing due to another keyword
+not found exception.
 
-Now when you run `robot robot/login.robot` you should see browser opening and accessing to SUT and then failing due to another keyword not found exception.
+If you have something like `Navigate to localhost:7272` that can be removed since the `New Page` will
+already go to that website.
 
-If you have something like `Navigate to localhost:7272` that can be removed since the `Open Browser` will already go to that website.
-
-Your job now is to figure out what SeleniumLibrary keywords you can use to input username and password, and click the login element.
+Your job now is to figure out what Browser-library keywords you can use to input username and password,
+and click the login element.
 
 You need to open the source code for the web page to find the element IDs.
 
-To verify that welcome page is visible you can check the page content, url and title.
+To verify that welcome page is visible you can check the page content, url and title. With the Browser-library,
+vefications (or assertions) can be done in combination with the `Get ...`-keywords, for example `Get Title    ==    Welcome Page`. More information at https://marketsquare.github.io/robotframework-browser/Browser.html#Assertions.
 
 After you've successfully run the test case with `robot robot/login.robot` you should see output like this:
 
-```
+```text
 ==============================================================================
 Login
 ==============================================================================
@@ -203,7 +248,7 @@ Login                                                                 | PASS |
 
 After you've made the test pass, ensure that it's done with right manner by running:
 
-  - Windows: double click `02-robot_syntax.cmd`
-  - Linux/macOS: run `./exercises/verify/02-robot_syntax.sh`
+- Windows: double click `02-robot_syntax.cmd`
+- Linux/macOS: run `./exercises/verify/02-robot_syntax.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/02-robot-syntax.md
+++ b/exercises/02-robot-syntax.md
@@ -162,10 +162,10 @@ opens by default in a _headless_ state. Headless simply means that the GUI is no
 is to make test performance better. We need to open the browser specifically in a headful state if we
 want to see what is happening during the test.
 
-Before getting into how to do that, let's expain three important Browser-library concepts: browser,
+Before getting into how to do that, let's explain three important Browser-library concepts: browser,
 context, and page.
 
-- _Browser_ indicates a browser - Chromium (Chrome, Edge, Opera), Firefox, or Webkit (Safari).
+- _Browser_ indicates a browser - Chromium (Chrome, Edge, Opera), Firefox, or WebKit (Safari).
 - _Context_ includes cookies, sessions, profile settings etc. A context is opened within a browser.
 - _Page_ is simply a webpage (or a tab) which is opened inside a browser. A page is opened within a context.
 
@@ -177,7 +177,7 @@ If we want to open a browser in a headful state, we'll have to call the `New Bro
 (before calling `New Page`) with a specific argument defining this: `headless=${FALSE}`. The context
 is still created with default arguments, and at this point there's no need to adjust those.
 
-*Pro tip:* as everything else, arguments can be specified by leaving at least 2 (preferably 4) spaces
+*Pro-tip:* as everything else, arguments can be specified by leaving at least 2 (preferably 4) spaces
 between the keyword and them.
 
 Running the tests headful is not necessary for the final test, but it makes debugging a lot easier
@@ -216,7 +216,7 @@ Welcome Page Should Be Visible After Successful Login
     Check That Welcome Page Text Is Visible
 ```
 
-*Note:* Make sure that the SUT is running on it's own windows and that you can access it with address
+*Note:* Make sure that the SUT is running in its own window and that you can access it with address
 http://localhost:7272.
 
 Now you can see browser actually opening and accessing to SUT and then failing due to another keyword
@@ -230,8 +230,8 @@ and click the login element.
 
 You need to open the source code for the web page to find the element IDs.
 
-To verify that welcome page is visible you can check the page content, url and title. With the Browser-library,
-vefications (or assertions) can be done in combination with the `Get ...`-keywords, for example `Get Title    ==    Welcome Page`. More information at https://marketsquare.github.io/robotframework-browser/Browser.html#Assertions.
+To verify that welcome page is visible you can check the page content, URL and title. With the Browser-library,
+verifications (or assertions) can be done in combination with the `Get ...`-keywords, for example `Get Title    ==    Welcome Page`. More information at https://marketsquare.github.io/robotframework-browser/Browser.html#Assertions.
 
 After you've successfully run the test case with `robot robot/login.robot` you should see output like this:
 
@@ -252,4 +252,4 @@ After you've made the test pass, ensure that it's done with right manner by runn
 - Windows: double click `02-robot_syntax.cmd`
 - Linux/macOS: run `./exercises/verify/02-robot_syntax.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/exercises/02-robot-syntax.md
+++ b/exercises/02-robot-syntax.md
@@ -90,7 +90,8 @@ Now in order to have the `New Page` we need to define it under the test case and
 
 Note that keywords are actually case-insensitive, so `new page`, `NEW PAGE`, `New page`,
 and `NeW pAgE` will all work. However, the recommended way is to capitalize the first letter of
-each word, like `New Page` in this case.
+each word, like `New Page` in this case. More information can be found from the
+*[How to write good test cases using Robot Framework](https://github.com/robotframework/HowToWriteGoodTestCases/blob/master/HowToWriteGoodTestCases.rst#naming)*-guide.
 
 ```robot
 *** Test Cases ***

--- a/exercises/03-keywords_and_variables.md
+++ b/exercises/03-keywords_and_variables.md
@@ -92,7 +92,7 @@ Ensure you refactored test is still passing by running `robot robot/login.robot`
 
 But hey! Doesn't our test case look nice and clean? With UTF-8 support you can write those user defined
 keywords and test case names practically any language that you want: Finnish, Swedish, Russian, Traditional
-Chinese, what ever suites your project/company policy.
+Chinese, or what ever suites your project/company policy.
 
 ## Variables
 
@@ -115,8 +115,8 @@ Defining variables can be done with the following syntax:
 ${VARIABLE_NAME} =    variable value
 ```
 
-The `=` is optional and can be removed if you don't want to use it. You still need to have at least 2 spaces
-(preferably at least 4) between `${VARIABLE_NAME}` and `variable value`. Also, variable names are completely
+The `=` is optional and can be removed if you don't want to use it. You still need to have two or more
+(preferably at least four) spaces between `${VARIABLE_NAME}` and `variable value`. Also, variable names are completely
 case-insensitive. Robot also ignores spaces and `_` signs. This means that to robot these variables names:
 `${MYVARIABLE}`, `${MyVariable}`, `${MY VARIABLE}`, `${My_variable}`, and `${myvariable}` are actually all
 referring to the same variable. The recommended best practice is to define variables in the `*** Variables ***`

--- a/exercises/03-keywords_and_variables.md
+++ b/exercises/03-keywords_and_variables.md
@@ -36,7 +36,7 @@ Welcome Page Should Be Visible After Successful Login
 
 </details>
 
-This test is technically correct, but can be quite hard to read if you don't know e.g. what is a HTML
+This test is technically correct, but can be quite hard to read if you don't know e.g. what is an HTML
 attribute `id`.
 
 In other words, we need to refactor our test a bit.
@@ -68,11 +68,11 @@ After the possible fixes create the following keywords:
 - `Submit Login Form`
 - `Verify That Welcome Page Is Visible`
 
-*Pro tip 1:* One user defined keyword can contain multiple keywords, just like a test case can have
+*Pro-tip 1:* One user defined keyword can contain multiple keywords, just like a test case can have
 multiple steps. This can be used to shorten test cases by hiding long chains of actions inside aptly
 named keywords.
 
-*Pro tip 2:* User defined keywords can become more versatile, through the use of arguments:
+*Pro-tip 2:* User defined keywords can become more versatile, through the use of arguments:
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#user-keyword-arguments
 
 After you've defined and implemented the keywords your test case should look like this:
@@ -119,7 +119,7 @@ The `=` is optional and can be removed if you don't want to use it. You still ne
 (preferably at least 4) between `${VARIABLE_NAME}` and `variable value`. Also, variable names are completely
 case-insensitive. Robot also ignores spaces and `_` signs. This means that to robot these variables names:
 `${MYVARIABLE}`, `${MyVariable}`, `${MY VARIABLE}`, `${My_variable}`, and `${myvariable}` are actually all
-referring to the same variable. The recomended best practice is to define variables in the `*** Variables ***`
+referring to the same variable. The recommended best practice is to define variables in the `*** Variables ***`
 table in ALL CAPS. This is purely to help everyone better distinguish the scope of variables (use upper
 case for global, suite, and test variables and lower case for keyword variables).
 
@@ -132,12 +132,12 @@ ${URL} =    http://localhost:7272
 
 Now replace all the existing `http://localhost:7272` with `${URL}`.
 
-*Pro tip:* You can combine variables with text like this `${URL}/` or `${URL}/welcome.html` without
+*Pro-tip:* You can combine variables with text like this `${URL}/` or `${URL}/welcome.html` without
 any concatenation or arithmetic operations.
 
 After you've made changes, run the `robot robot/login.robot` to verify that the test is still passing.
 
-*Pro tip:* If you don't want to actually run the test case but just check the syntax you can also run
+*Pro-tip:* If you don't want to actually run the test case but just check the syntax you can also run
 `robot --dryrun robot/login.robot`. Check `robot -h` for more details.
 
 Now that you've successfully changed to use `${URL}` variable, think about what other values could
@@ -148,7 +148,7 @@ Once you've done those, run the `robot robot/login.robot` to verify that changes
 
 To ensure that changes are done in right manner run:
 
-- Windows: double click the `03-keywords_and_variables.cmd`
+- Windows: double-click the `03-keywords_and_variables.cmd`
 - Linux/macOS: run `./exercises/verify/03-keywords_and_variables.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/exercises/03-keywords_and_variables.md
+++ b/exercises/03-keywords_and_variables.md
@@ -1,74 +1,83 @@
 # Keywords and variables
 
-One of the most powerful things that Robot Framework can do is to provide the capability to write test cases
-using natural language. In an ideal world, it is not just people who write those tests, but also other people are interested in the automated test case results, including
-how, where, and when they are run.
+One of the most powerful things that Robot Framework can do is to provide the capability to write test
+cases using natural language. In an ideal world, it is not just people who write those tests, but also
+other people are interested in the automated test case results, including how, where, and when they are
+run.
 
 This can be made possible by using user defined keywords:
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#creating-user-keywords
 
 ## User defined keywords
 
-With user defined keywords we can create abstraction layer when needed.
-A general rule of thumb is that library and resource keywords are "general sounding" ones and with user keywords in test suite you can create needed abstraction layer based on the test context.
+With user defined keywords we can create abstraction layer when needed. A general rule of thumb is that
+library and resource keywords are "general sounding" ones and with user keywords in test suite you can
+create needed abstraction layer based on the test context.
 
 <details>
     <summary>From previous exercises we should have something like this in our <code>robot/login.robot</code></summary>
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 
 *** Test Cases ***
 
 Welcome Page Should Be Visible After Successful Login
-    Open Browser    http://localhost:7272   browser=ff
-    Input Text    id=username_field    demo
-    Input Password    id=password_field    mode
-    Click Element    id=login_button
-    Page Should Contain    Welcome Page
-    Location Should Be    http://localhost:7272/welcome.html
-    Title Should Be    Welcome Page
+    New Browser    headless=${FALSE}
+    New Page    http://localhost:7272
+    Fill Text    id=username_field    demo
+    Fill Secret    id=password_field    mode
+    Click    id=login_button
+    Get Text    id=header    ==    Welcome Page
+    Get Url    ==    http://localhost:7272/welcome.html
+    Get Title    ==    Welcome Page
 ```
 
 </details>
 
-This test is technically correct, but can be quite hard to read if you don't know e.g. what is HTML attribute `id`.
+This test is technically correct, but can be quite hard to read if you don't know e.g. what is a HTML
+attribute `id`.
 
 In other words, we need to refactor our test a bit.
 
 We need to add a new table `*** Keywords ***`. It can be above or below the `*** Test Cases ***`.
 
-Under `Keywords` table we need to create a new keyword called `Open Browser To Login Page`. The same indentation
-rules apply with keywords as in test cases: each unindented line is considered a new keyword, so the implementation
-of the keyword need to be indented with 4 spaces.
+Under the `Keywords` table we need to create a new keyword called `Open Browser To Login Page`. The
+same indentation rules apply with keywords as in test cases: each unindented line is considered a new
+keyword, so the implementation of the keyword need to be indented with 4 spaces.
 
-```
+```robot
 *** Keywords ***
 
 Open Browser To Login Page
-    Open Browser    http://localhost:7272   browser=ff
+    New Browser    headless=${FALSE}
+    New Page    http://localhost:7272
 ```
 
-Now, we can replace our `Open Browser    http://localhost:7272   browser=ff` from our test case with our own
-user defined keyword `Open Browser To Login Page` to provide context to our test case.
+Now, we can replace the first two lines from our test case with our own user defined keyword
+`Open Browser To Login Page` to provide context to our test case.
 
-You can test out that your refactoring was done correctly by running `robot robot/login.robot` and to see that test is still passing.
+You can test out that your refactoring was done correctly by running `robot robot/login.robot` and
+to see that test is still passing.
 
 After the possible fixes create the following keywords:
 
-  - `Enter Username`
-  - `Enter Password`
-  - `Submit Login Form`
-  - `Verify That Welcome Page Is Visible`
+- `Enter Username`
+- `Enter Password`
+- `Submit Login Form`
+- `Verify That Welcome Page Is Visible`
 
-*Pro tip 1* One user defined keyword can contain multiple keywords, just like a test case can have multiple steps. This can be used to shorten test cases by hiding long chains of actions inside aptly named keywords.
+*Pro tip 1:* One user defined keyword can contain multiple keywords, just like a test case can have
+multiple steps. This can be used to shorten test cases by hiding long chains of actions inside aptly
+named keywords.
 
-*Pro tip 2* User defined keywords can become more versatile, through the use of arguments: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#user-keyword-arguments
+*Pro tip 2:* User defined keywords can become more versatile, through the use of arguments:
+http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#user-keyword-arguments
 
 After you've defined and implemented the keywords your test case should look like this:
 
-```
+```robot
 *** Test Cases ***
 
 Welcome Page Should Be Visible After Successful Login
@@ -81,59 +90,65 @@ Welcome Page Should Be Visible After Successful Login
 
 Ensure you refactored test is still passing by running `robot robot/login.robot`.
 
-But hey! Doesn't our test case look nice and clean? With UTF-8 support you can write those user defined keywords and test case names practically any language that you want: Finnish, Swedish, Russian, Traditional Chinese, what ever suites your project/company policy.
-
+But hey! Doesn't our test case look nice and clean? With UTF-8 support you can write those user defined
+keywords and test case names practically any language that you want: Finnish, Swedish, Russian, Traditional
+Chinese, what ever suites your project/company policy.
 
 ## Variables
 
 Robot Framework does support variables: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#variables
 
-A benefit of using variables instead of hard coded values here and there, is to provide a single place where to change the value, when needed, which can return all the tests that use the variable back to working once again (if nothing else needs changing). This will increase the maintainability of the test cases.
+A benefit of using variables instead of hard coded values here and there, is to provide a single place
+where to change the value, when needed, which can return all the tests that use the variable back to
+working once again (if nothing else needs changing). This will increase the maintainability of the test
+cases.
 
 Let's modify our test to use variables.
 
-A key aspect in using variables is discovering what values could change more often. For example, one that is likely
-to change is the location where the SUT is running. In order to add variables to our test suite,
-we need to create a `*** Variables ***` table.
+A key aspect in using variables is discovering what values could change more often. For example, one
+that is likely to change is the location where the SUT is running. In order to add variables to our
+test suite, we need to create a `*** Variables ***` table.
 
 Defining variables can be done with the following syntax:
-```
-${VARIABLE_NAME}=    variable value
+
+```robot
+${VARIABLE_NAME} =    variable value
 ```
 
 The `=` is optional and can be removed if you don't want to use it. You still need to have at least 2 spaces
 (preferably at least 4) between `${VARIABLE_NAME}` and `variable value`. Also, variable names are completely
 case-insensitive. Robot also ignores spaces and `_` signs. This means that to robot these variables names:
-`${MYVARIABLE}`, `${MyVariable}`, `${MY VARIABLE}`, `${My_variable}`, and `${myvariable}` are actually all referring to the same variable.
-The recomended best practice is to define variables in the `*** Variables ***` table in ALL CAPS. This is
-purely to help everyone better distinguish the scope of variables (use upper case for global, suite, and test variables and lower
-case for keyword variables).
+`${MYVARIABLE}`, `${MyVariable}`, `${MY VARIABLE}`, `${My_variable}`, and `${myvariable}` are actually all
+referring to the same variable. The recomended best practice is to define variables in the `*** Variables ***`
+table in ALL CAPS. This is purely to help everyone better distinguish the scope of variables (use upper
+case for global, suite, and test variables and lower case for keyword variables).
 
 Let's add our `Variables` table and `URL` as a variable.
 
-```
+```robot
 *** Variables ***
-${URL}=    http://localhost:7272
+${URL} =    http://localhost:7272
 ```
 
 Now replace all the existing `http://localhost:7272` with `${URL}`.
 
-*Pro tip* You can combine variables with text like this `${URL}/` or `${URL}/welcome.html` without any concatenation or arithmetic operations.
+*Pro tip:* You can combine variables with text like this `${URL}/` or `${URL}/welcome.html` without
+any concatenation or arithmetic operations.
 
 After you've made changes, run the `robot robot/login.robot` to verify that the test is still passing.
 
-*Pro tip* If you don't want to actually run the test case but just check the syntax you can also run `robot --dryrun robot/login.robot`. Check `robot -h` for more details.
+*Pro tip:* If you don't want to actually run the test case but just check the syntax you can also run
+`robot --dryrun robot/login.robot`. Check `robot -h` for more details.
 
-
-Now that you've successfully changed to use `${URL}` variable,
-think about what other values could change except the domain of the SUT.
-Create those variables and modify the test case to use them instead of hard coded values.
+Now that you've successfully changed to use `${URL}` variable, think about what other values could
+change except the domain of the SUT. Create those variables and modify the test case to use them instead
+of hard coded values.
 
 Once you've done those, run the `robot robot/login.robot` to verify that changes are done correctly.
 
 To ensure that changes are done in right manner run:
 
-  - Windows: double click the `03-keywords_and_variables.cmd`
-  - Linux/macOS: run `./exercises/verify/03-keywords_and_variables.sh`
+- Windows: double click the `03-keywords_and_variables.cmd`
+- Linux/macOS: run `./exercises/verify/03-keywords_and_variables.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/03-keywords_and_variables.md
+++ b/exercises/03-keywords_and_variables.md
@@ -68,11 +68,11 @@ After the possible fixes create the following keywords:
 - `Submit Login Form`
 - `Verify That Welcome Page Is Visible`
 
-*Pro-tip 1:* One user defined keyword can contain multiple keywords, just like a test case can have
+*Pro-tip:* One user defined keyword can contain multiple keywords, just like a test case can have
 multiple steps. This can be used to shorten test cases by hiding long chains of actions inside aptly
 named keywords.
 
-*Pro-tip 2:* User defined keywords can become more versatile, through the use of arguments:
+*Pro-tip:* User defined keywords can become more versatile, through the use of arguments:
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#user-keyword-arguments
 
 After you've defined and implemented the keywords your test case should look like this:

--- a/exercises/03-keywords_and_variables.md
+++ b/exercises/03-keywords_and_variables.md
@@ -29,7 +29,7 @@ Welcome Page Should Be Visible After Successful Login
     Fill Text    id=username_field    demo
     Fill Secret    id=password_field    mode
     Click    id=login_button
-    Get Text    id=header    ==    Welcome Page
+    Get Text    body    contains    Welcome Page
     Get Url    ==    http://localhost:7272/welcome.html
     Get Title    ==    Welcome Page
 ```

--- a/exercises/04-setups_and_teardowns.md
+++ b/exercises/04-setups_and_teardowns.md
@@ -100,7 +100,7 @@ Login Form Should Be Visible After Successful Logout
     # rest of the implementation
 ```
 
-*Tip:* `#` starts a comment line for Robot Framework. Nothing after it will be executed.
+*Pro-tip:* `#` starts a comment line for Robot Framework. Nothing after it will be executed.
 
 Existence of `Setup` indicates to the test case reader, that there is some precondition before our
 actual test execution.
@@ -122,7 +122,7 @@ in that.)
 
 The teardown is defined a similar way as was setup, using the `[Teardown]` option.
 
-*Tip:* In order to make the `Login Form Should Be Visible After Successful Logout` test work, you've
+*Pro-tip:* In order to make the `Login Form Should Be Visible After Successful Logout` test work, you've
 probably created a `Do Successful Logout` keyword for logging out. Maybe we could utilize
 that in the teardown?
 

--- a/exercises/04-setups_and_teardowns.md
+++ b/exercises/04-setups_and_teardowns.md
@@ -1,6 +1,6 @@
 # Setups and Teardowns
 
-Robot Framework provides features called _Setup_ and _Teardown_ to help with repetive parts that
+Robot Framework provides features called _Setup_ and _Teardown_ to help with repetitive parts that
 which are required to run the test, but are not necessary _part_ of the tests. In our case such things
 would be e.g. opening and closing the browser. More details can be found at
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-setup-and-teardown.
@@ -62,7 +62,7 @@ Name the new test case `Login Form Should Be Visible After Successful Logout`.
 
 After implementing the new test case run both of the test cases with command
 `robot --randomize tests robot/login.robot` to make sure that they're not executed in order all the
-time. This helps to ensure that all tests pass regardless of what order they are ran in. Check
+time. This helps to ensure that all tests pass regardless of what order they are run in. Check
 `robot -h` for more info.
 
 You may have noticed that you just copy-pasted the `Welcome Page Should Be Visible After Successful Login`
@@ -103,7 +103,7 @@ Existence of `Setup` indicates to the test case reader, that there is some preco
 ## Test Teardown
 
 Teardown works similarly to Setup with the main difference being that it will be executed after the
-main part of the test has run. Teardowns are run _always_, regardless whether the test succeeds or
+main part of the test has run. Teardowns are _always_ run, regardless whether the test succeeds or
 fails.
 
 Similarly to the `[Setup]`, a teardown would be defined with a `[Teardown]` option in the end of the
@@ -115,7 +115,7 @@ by default after each test case. (This setup can be changed with one of the Brow
 
 To ensure that changes are done in right manner run:
 
-- Windows: double click the `04-setups_and_teardowns.cmd`
+- Windows: double-click the `04-setups_and_teardowns.cmd`
 - Linux/macOS: run `./exercises/verify/04-setups_and_teardowns.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/exercises/04-setups_and_teardowns.md
+++ b/exercises/04-setups_and_teardowns.md
@@ -1,9 +1,11 @@
 # Setups and Teardowns
 
-Robot Framework provides features called _Setup_ and _Teardown_ to help with repetitive parts that
-which are required to run the test, but are not necessary _part_ of the tests. In our case such things
-would be e.g. opening and closing the browser. More details can be found at
-http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-setup-and-teardown.
+Robot Framework provides features called _Setup_ and _Teardown_ to help with repetitive parts
+which are required to initialize or disassemble the tests, but are not necessary _part_ of them. In
+our case such things would be e.g. opening and closing the browser, and perhaps in some cases, logging
+out.
+
+More details on setup and teardown can be found from the corresponding [Test setup and teardown](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-setup-and-teardown)-documentation.
 
 <details>
     <summary>From our previous exercises our <code>login.robot</code> should look something like this</summary>
@@ -51,9 +53,9 @@ Verify That Welcome Page Is Visible
 
 </details>
 
-## Test Setup
+As was defined in SUT features, the logout link is only visible after a successful login. So far we
+have not made any tests to validate that logging out works as expected, but perhaps we should?
 
-As was defined in SUT features, the logout link is only visible after successful login.
 Create a new test case that first logins and then clicks the logout link, since we want to
 make our test cases so that they can be run individually. Remember to create a keyword to
 verify the login form visibility.
@@ -68,11 +70,13 @@ time. This helps to ensure that all tests pass regardless of what order they are
 You may have noticed that you just copy-pasted the `Welcome Page Should Be Visible After Successful Login`
 test steps, then proceeded to click the link and verify that login form is visible.
 
-The new test case is now quite long, which makes it harder to understand. It should be easier to
-comprehend the main point of the test for people reading the steps (it also should be clear from the
-test case name). To improve the readability, add a proper test setup for the test case.
+## Test Setup
 
-To do that let's create new keyword called `Do Successful Login` with following content:
+The new test case is now quite long, which makes it harder to understand. It should be as easy as possible
+to comprehend the main point of the test for people reading the steps (it also should be clear from the
+test case name). Let's improve the readability by adding a proper test setup for the test case.
+
+To do that we need to create a new keyword called `Do Successful Login` with following content:
 
 ```robot
 Do Successful Login
@@ -82,7 +86,7 @@ Do Successful Login
     Submit Login Form
 ```
 
-Now refactor both test cases by adding that part to test setup with `[Setup]` option.
+Then we can refactor both test cases by adding that part to test setup with `[Setup]` option.
 
 Now the test cases should look something like this:
 
@@ -98,20 +102,29 @@ Login Form Should Be Visible After Successful Logout
 
 *Tip:* `#` starts a comment line for Robot Framework. Nothing after it will be executed.
 
-Existence of `Setup` indicates to the test case reader, that there is some precondition before our actual test execution.
+Existence of `Setup` indicates to the test case reader, that there is some precondition before our
+actual test execution.
 
 ## Test Teardown
 
-Teardown works similarly to Setup with the main difference being that it will be executed after the
-main part of the test has run. Teardowns are _always_ run, regardless whether the test succeeds or
-fails.
+Teardown works similarly to setup, with the main difference being that it will be executed after the
+main part of the test has run. If teardowns are defined, they're _always_ run, regardless whether the
+test succeeds or fails mid-execution.
 
-Similarly to the `[Setup]`, a teardown would be defined with a `[Teardown]` option in the end of the
-test case. So for example, if we would want to ensure that the browser is closed after the test, we
-could add a `[Teardown]    Close Browser` to the end. This would run the `Close Browser` keyword every
-time after the test. In our case it is _not necessary_, as the Browser-library closes all open browsers
-by default after each test case. (This setup can be changed with one of the Browser's
-[import arguments](https://marketsquare.github.io/robotframework-browser/Browser.html#Importing).)
+As explained in the introduction to this exercise, one of the main ideas of setups and teardowns is
+wrapping the non-testing parts into them. Neither setups nor teardowns have to be the same in every
+single test case, even within a suite (which was simply a single file with one or more test cases).
+We have two tests that test two different things.
+
+Perhaps we could add a teardown to the first test case which the user out after the test. (Note that
+the second test case already does a logout *as part of the test*, so the teardown would not be needed
+in that.)
+
+The teardown is defined a similar way as was setup, using the `[Teardown]` option.
+
+*Tip:* In order to make the `Login Form Should Be Visible After Successful Logout` test work, you've
+probably created a `Do Successful Logout` keyword for logging out. Maybe we could utilize
+that in the teardown?
 
 To ensure that changes are done in right manner run:
 

--- a/exercises/04-setups_and_teardowns.md
+++ b/exercises/04-setups_and_teardowns.md
@@ -1,21 +1,21 @@
 # Setups and Teardowns
 
-You probably noticed that when you run `robot robot/login.robot`, the automated run will always leave one browser
-window open. Wouldn't it be nice if the test automatically closes the browser after the test is executed?
-Robot Framework provides setups and teardowns to fix that issue:
-http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-setup-and-teardown
+Robot Framework provides features called _Setup_ and _Teardown_ to help with repetive parts that
+which are required to run the test, but are not necessary _part_ of the tests. In our case such things
+would be e.g. opening and closing the browser. More details can be found at
+http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-setup-and-teardown.
 
 <details>
     <summary>From our previous exercises our <code>login.robot</code> should look something like this</summary>
 
 ```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 
 *** Variables ***
-${URL}=    http://localhost:7272
-${USERNAME}=    demo
-${PASSWORD}=    mode
+${URL} =    http://localhost:7272
+${USERNAME} =    demo
+${PASSWORD} =    mode
 
 *** Test Cases ***
 
@@ -26,67 +26,30 @@ Welcome Page Should Be Visible After Successful Login
     Submit Login Form
     Verify That Welcome Page Is Visible
 
-
 *** Keywords ***
 
 Open Browser To Login Page
-    Open Browser    ${URL}   browser=ff
+    New Browser    headless=${FALSE}
+    New Page    ${URL}
 
 Enter Username
     [Arguments]    ${username}
-    Input Text    id=username_field    ${username}
+    Fill Text    id=username_field    ${username}
 
 Enter Password
     [Arguments]    ${password}
-    Input Password    id=password_field    ${password}
+    Fill Secret    id=password_field    ${password}
 
 Submit Login Form
-    Click Element    id=login_button
+    Click    id=login_button
 
 Verify That Welcome Page Is Visible
-    Page Should Contain    Welcome Page
-    Location Should Be    ${URL}/welcome.html
-    Title Should Be    Welcome Page
+    Get Text    id=header    ==    Welcome Page
+    Get Url    ==    ${URL}/welcome.html
+    Get Title    ==    Welcome Page
 ```
 
 </details>
-
-Add `Close Browser` (https://robotframework.org/SeleniumLibrary/SeleniumLibrary.html#Close%20Browser)
-after the last keyword `Verify That Welcome Page is Visible` has been executed. When you run your test,
-the browser should close automatically and the test still passes.
-
-Let's make a small error in our test and see what happens. Make a typo in the `Title Should Be` keyword
-(inside the `Verify That Welcome Page Is Visible` keyword) parameter to for example `Welcome poge`.
-
-Now run `robot robot/login.robot`. Did the browser close?
-
-The reason why the browser didn't close is because the test failed in the keyword
-`Verify That Welcome Page Is Visible`. When a test fails, the execution stops and all keywords that
-are after the failing keyword aren't executed anymore. Close the browser manually.
-
-## Test Teardown
-
-Let's modify our test case a bit and let's add a `Teardown` into our test case. Add `[Teardown]` before
-`Close Browser` (on the same line, remember to leave 4 spaces between the two), so that our test case
-looks like this:
-
-```
-Welcome Page Should Be Visible After Sucecsfull Login
-    Open Browser To Login Page
-    Enter Username
-    Enter Password
-    Submit Login Form
-    Verify That Welcome Page Is Visible
-    [Teardown]    Close Browser
-```
-
-Now run the `robot robot/login.robot` and what happened? Test case failed,
-but the browser was still closed? Open the log.html and you can see that now
-the `Close Browser` was executed as a test teardown. A teardown is always executed regardless
-to the outcome of the test.
-
-Fix the typo we created to `Title Should Be` inside `Verify That Welcome Page Is Open` keyword
-to make the test green once again.
 
 ## Test Setup
 
@@ -97,24 +60,21 @@ verify the login form visibility.
 
 Name the new test case `Login Form Should Be Visible After Successful Logout`.
 
-
-*Pro tip.* Check from the SeleniumLibrary keywords library how to click links.
-
 After implementing the new test case run both of the test cases with command
-`robot --randomize tests robot/login.robot` to make sure that they're not
-executed in order all the time. This helps to ensure that all tests pass regardless of
-what order they are ran in. Check `robot -h` for more info.
+`robot --randomize tests robot/login.robot` to make sure that they're not executed in order all the
+time. This helps to ensure that all tests pass regardless of what order they are ran in. Check
+`robot -h` for more info.
 
 You may have noticed that you just copy-pasted the `Welcome Page Should Be Visible After Successful Login`
 test steps, then proceeded to click the link and verify that login form is visible.
 
 The new test case is now quite long, which makes it harder to understand. It should be easier to
-comprehend the main point of the test for people reading the steps (it also should be clear from the test case name).
-To improve the readability, add a proper test setup for the test case.
+comprehend the main point of the test for people reading the steps (it also should be clear from the
+test case name). To improve the readability, add a proper test setup for the test case.
 
 To do that let's create new keyword called `Do Successful Login` with following content:
 
-```
+```robot
 Do Successful Login
     Open Browser To Login Page
     Enter Username
@@ -122,24 +82,40 @@ Do Successful Login
     Submit Login Form
 ```
 
-Refactor the `Login Form Should Be Visible After Successful Logout` test case by adding
-that part to test setup with `[Setup]` option.
+Now refactor both test cases by adding that part to test setup with `[Setup]` option.
 
-Now the test case should look something like this:
+Now the test cases should look something like this:
 
-```
+```robot
+Welcome Page Should Be Visible After Successful Login
+    [Setup]    Do Successful Login
+    # rest of the implementation
+
 Login Form Should Be Visible After Successful Logout
     [Setup]    Do Successful Login
     # rest of the implementation
 ```
 
-*Pro tip.*  `#` starts a comment line for Robot Framework, its contents will not be executed.
+*Tip:* `#` starts a comment line for Robot Framework. Nothing after it will be executed.
 
 Existence of `Setup` indicates to the test case reader, that there is some precondition before our actual test execution.
 
+## Test Teardown
+
+Teardown works similarly to Setup with the main difference being that it will be executed after the
+main part of the test has run. Teardowns are run _always_, regardless whether the test succeeds or
+fails.
+
+Similarly to the `[Setup]`, a teardown would be defined with a `[Teardown]` option in the end of the
+test case. So for example, if we would want to ensure that the browser is closed after the test, we
+could add a `[Teardown]    Close Browser` to the end. This would run the `Close Browser` keyword every
+time after the test. In our case it is _not necessary_, as the Browser-library closes all open browsers
+by default after each test case. (This setup can be changed with one of the Browser's
+[import arguments](https://marketsquare.github.io/robotframework-browser/Browser.html#Importing).)
+
 To ensure that changes are done in right manner run:
 
-  - Windows: double click the `04-setups_and_teardowns.cmd`
-  - Linux/macOS: run `./exercises/verify/04-setups_and_teardowns.sh`
+- Windows: double click the `04-setups_and_teardowns.cmd`
+- Linux/macOS: run `./exercises/verify/04-setups_and_teardowns.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/04-setups_and_teardowns.md
+++ b/exercises/04-setups_and_teardowns.md
@@ -44,7 +44,7 @@ Submit Login Form
     Click    id=login_button
 
 Verify That Welcome Page Is Visible
-    Get Text    id=header    ==    Welcome Page
+    Get Text    body    contains    Welcome Page
     Get Url    ==    ${URL}/welcome.html
     Get Title    ==    Welcome Page
 ```

--- a/exercises/05-negative_testing.md
+++ b/exercises/05-negative_testing.md
@@ -6,7 +6,8 @@ intended: when the user knows what they should do.
 Let's focus on negative testing, which means testing that the application behaves correctly
 when the user makes an error. In this case it means that the user inputs incorrect credentials.
 
-Think about different ways to mistype a combination of username and password, and write them in some file. Have at least 6 different combinations of incorrect credentials.
+Think about different ways to mistype a combination of username and password, and write them in some
+file. Have at least 6 different combinations of incorrect credentials.
 
 Checkout also Robot Framework built-in variables: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#built-in-variables
 
@@ -23,30 +24,38 @@ Remember to also create the keyword `Verify That Error Page Is Visible`.
 Run the test with `robot robot/invalid_login.robot` command to verify the results.
 
 In this exercise the task is to only test one of the six combinations you thought of earlier. However,
-there are at least six possible combinations. Creating a new keyword for entering credentials in each and every of those cases is kind of unnecessary
-repetition, since the only changing part is the value being entered in the field. This is where keyword arguments should be used. Keyword
-arguments work just like your variables in the `*** Variables ***` table, except it is best practice
-keyword arguments to write them in lower case.
+there are at least six possible combinations. Creating a new keyword for entering credentials in each
+and every of those cases is kind of unnecessary repetition, since the only changing part is the value
+being entered in the field. This is where keyword arguments should be used. Keyword arguments work
+just like your variables in the `*** Variables ***` table, except it is best practice keyword arguments
+to write them in lower case.
 
-Define keyword arguments to `Enter Username` and `Enter Password`
-by putting `[Arguments]` after the keyword name, just like you did with test
-`[Setup]` and `[Teardown]` for a test case in [exercise 04](./04-setups_and_teardowns.md). After these steps,
-you need four spaces and the name of your argument, resulting in:
+Define keyword arguments to `Enter Username` and `Enter Password` by putting `[Arguments]` after the
+keyword name, just like you did with test `[Setup]` for a test case in [exercise 04](./04-setups_and_teardowns.md).
+After these steps, you need four spaces and the name of your argument, resulting in:
 
-```
+```robot
 Enter Username
     [Arguments]    ${username}
 ```
 
-Also remember to change the input value in the `Input Text` keyword to use the `${username}` variable
+Also remember to change the input value in the `Fill Text` keyword to use the `${username}` variable
 instead of a hard-coded value.
 
-Note that if you have a `${USERNAME}` variable in the `*** Variables ***` table, and also use `${username}` as a keyword argument, then inside that keyword,
-all uses of both `${username}` and `${USERNAME}` will access only that keyword argument variable (in programming, this is called shadowing).
+Note that if you have a `${USERNAME}` variable in the `*** Variables ***` table, and also use
+`${username}` as a keyword argument, then inside that keyword all uses of both `${username}` and
+`${USERNAME}` will access only that keyword argument variable (in programming, this is called
+shadowing).
+
+*Pro tip:* The `Fill Secret` keyword might fail with an error saying `Invalid variable name ''`. This
+originates from how that specifc keyword handles variables. The filled data is considered as a _secret_, so the
+idea would be not to log it, even to the log-file. More information can be found from the [keyword-documentation](https://marketsquare.github.io/robotframework-browser/Browser.html#Fill%20Secret),
+but generally the error can be fixed by replacing the variable reference `${password}` with `$password`,
+as explained in the documentation.
 
 When the test passes run the following command to ensure that changes are done in right manner run:
 
-  - Windows: double click the `05-negative_testing.cmd`
-  - Linux/macOS: run `./exercises/verify/05-negative_testing.sh`
+- Windows: double click the `05-negative_testing.cmd`
+- Linux/macOS: run `./exercises/verify/05-negative_testing.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/05-negative_testing.md
+++ b/exercises/05-negative_testing.md
@@ -47,15 +47,15 @@ Note that if you have a `${USERNAME}` variable in the `*** Variables ***` table,
 `${USERNAME}` will access only that keyword argument variable (in programming, this is called
 shadowing).
 
-*Pro tip:* The `Fill Secret` keyword might fail with an error saying `Invalid variable name ''`. This
-originates from how that specifc keyword handles variables. The filled data is considered as a _secret_, so the
+*Pro-tip:* The `Fill Secret` keyword might fail with an error saying `Invalid variable name ''`. This
+originates from how that specific keyword handles variables. The filled data is considered as a _secret_, so the
 idea would be not to log it, even to the log-file. More information can be found from the [keyword-documentation](https://marketsquare.github.io/robotframework-browser/Browser.html#Fill%20Secret),
 but generally the error can be fixed by replacing the variable reference `${password}` with `$password`,
 as explained in the documentation.
 
 When the test passes run the following command to ensure that changes are done in right manner run:
 
-- Windows: double click the `05-negative_testing.cmd`
+- Windows: double-click the `05-negative_testing.cmd`
 - Linux/macOS: run `./exercises/verify/05-negative_testing.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/exercises/06-resource_files.md
+++ b/exercises/06-resource_files.md
@@ -8,7 +8,7 @@ existing test case from `login.robot` test suite to `invalid_login.robot`.
 
 ```
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 
 *** Variables ***
 ${URL}=    http://localhost:7272
@@ -23,28 +23,28 @@ Error Page Should Be Visible After Successful Login
     Enter Password    ${SPACE*2}
     Submit Login Form
     Verify That Error Page Is Visible
-    [Teardown]    Close Browser
 
 *** Keywords ***
 
 Open Browser To Login Page
-    Open Browser    ${URL}   browser=ff
+    New Browser    headless=${FALSE}
+    New Page    ${URL}
 
 Enter Username
     [Arguments]    ${username}
-    Input Text    id=username_field    ${username}
+    Fill Text    id=username_field    ${username}
 
 Enter Password
     [Arguments]    ${password}
-    Input Password    id=password_field    ${password}
+    Fill Secret    id=password_field    $password
 
 Submit Login Form
-    Click Element    id=login_button
+    Click    id=login_button
 
 Verify That Error Page Is Visible
-    Page Should Contain    Error Page
-    Location Should Be    ${URL}/error.html
-    Title Should Be    Error Page
+    Get Text    id=header    ==    Error Page
+    Get Url    ==    ${URL}/error.html
+    Get Title    ==    Error Page
 ```
 
 </details>
@@ -66,7 +66,7 @@ Now do a cross-check between `login.robot` and `invalid_login.robot`. Find the d
 
 Now run the command `robot robot` to run all suites and you may notice some errors.
 
-```
+```text
 =============================================================================
 Login & Invalid Login
 ==============================================================================
@@ -98,7 +98,7 @@ Login & Invalid Login                                                 | FAIL |
 ==============================================================================
 ```
 
-Why is that? We've it in our `resource.robot`, right?
+Why is that? We have the keywords in our `resource.robot`, right?
 
 The reason is the same that we had with non `Builtin` Libraries. We need to tell the Robot Framework
 to use our `resource.robot` in our test suite.
@@ -108,9 +108,9 @@ your test suite file. Resource files can also resource other resource files.
 
 Let's modify the `login.robot` settings table by adding the `Resource` option there.
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 Resource    resource.robot
 ```
 
@@ -122,7 +122,7 @@ Create 2 more test cases that uses 2 different combination of invalid credential
 
 When the tests pass run the following command to ensure that changes are done in right manner run:
 
-  - Windows: double click the `06-resource_files.cmd`
-  - Linux/macOS: run `./exercises/verify/06-resource_files.sh`
+- Windows: double click the `06-resource_files.cmd`
+- Linux/macOS: run `./exercises/verify/06-resource_files.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/06-resource_files.md
+++ b/exercises/06-resource_files.md
@@ -55,13 +55,15 @@ Usually we don't want to repeat ourselves that much, since it makes maintenance 
 To ease out maintenance we can use resource files:
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#resource-and-variable-files
 
-The biggest difference between resource files and test suite files is that in a resource file you don't have the
-`*** Test Cases ***` or `*** Tasks ***` table.
+The biggest difference between resource files and test suite files is that in a resource file you
+don't have the `*** Test Cases ***` or `*** Tasks ***` table. It is [recommended](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#taking-resource-files-into-use)
+to use a `.resource` extension with resource files (instead of the otherwise used `.robot`). This is
+just for separating resource files from test files. The functionality will remain the same.
 
-So let's create our `resource.robot` file under `robot`.
+So let's create our `common.resource` file under `robot`.
 
 Now do a cross-check between `login.robot` and `invalid_login.robot`. Find the duplicate keywords from
-`login.robot` and `invalid_login.robot` and move them to `resource.robot`. Remove these keywords from
+`login.robot` and `invalid_login.robot` and move them to `common.resource`. Remove these keywords from
 `login.robot` and `invalid_login.robot`.
 
 Now run the command `robot robot` to run all suites. You may notice some errors.
@@ -98,10 +100,10 @@ Login & Invalid Login                                                 | FAIL |
 ==============================================================================
 ```
 
-Why is that? We have the keywords in our `resource.robot`, right?
+Why is that? We have the keywords in our `common.resource`, right?
 
 The reason is the same that we had with non `Builtin` Libraries. We need to tell the Robot Framework
-to use our `resource.robot` in our test suite.
+to use our `common.resource` in our test suite.
 
 That's why you need to add `Resources` four spaces `<resource_name>` to your `*** Settings ***` table in
 your test suite file. Resource files can also resource other resource files.
@@ -111,7 +113,7 @@ Let's modify the `login.robot` settings table by adding the `Resource` option th
 ```robot
 *** Settings ***
 Library    Browser
-Resource    resource.robot
+Resource    common.resource
 ```
 
 Now, when you run `robot robot/login.robot`, the tests should pass again.

--- a/exercises/06-resource_files.md
+++ b/exercises/06-resource_files.md
@@ -6,7 +6,7 @@ existing test case from `login.robot` test suite to `invalid_login.robot`.
 <details>
     <summary>So your <code>invalid_login.robot</code> could look something like this</summary>
 
-```
+```robot
 *** Settings ***
 Library    Browser
 

--- a/exercises/06-resource_files.md
+++ b/exercises/06-resource_files.md
@@ -42,7 +42,7 @@ Submit Login Form
     Click    id=login_button
 
 Verify That Error Page Is Visible
-    Get Text    id=header    ==    Error Page
+    Get Text    body    contains    Error Page
     Get Url    ==    ${URL}/error.html
     Get Title    ==    Error Page
 ```

--- a/exercises/06-resource_files.md
+++ b/exercises/06-resource_files.md
@@ -64,7 +64,7 @@ Now do a cross-check between `login.robot` and `invalid_login.robot`. Find the d
 `login.robot` and `invalid_login.robot` and move them to `resource.robot`. Remove these keywords from
 `login.robot` and `invalid_login.robot`.
 
-Now run the command `robot robot` to run all suites and you may notice some errors.
+Now run the command `robot robot` to run all suites. You may notice some errors.
 
 ```text
 =============================================================================
@@ -103,7 +103,7 @@ Why is that? We have the keywords in our `resource.robot`, right?
 The reason is the same that we had with non `Builtin` Libraries. We need to tell the Robot Framework
 to use our `resource.robot` in our test suite.
 
-That's why you need to add `Resources` 4 spaces `<resource_name>` to your `*** Settings ***` table in
+That's why you need to add `Resources` four spaces `<resource_name>` to your `*** Settings ***` table in
 your test suite file. Resource files can also resource other resource files.
 
 Let's modify the `login.robot` settings table by adding the `Resource` option there.
@@ -118,11 +118,11 @@ Now, when you run `robot robot/login.robot`, the tests should pass again.
 
 Add missing `Resource` option to `robot/invalid_login.robot` file as well and ensure your tests are passing.
 
-Create 2 more test cases that uses 2 different combination of invalid credentials to `invalid_login.robot`.
+Create two more test cases that use two different combination of invalid credentials to `invalid_login.robot`.
 
 When the tests pass run the following command to ensure that changes are done in right manner run:
 
-- Windows: double click the `06-resource_files.cmd`
+- Windows: double-click the `06-resource_files.cmd`
 - Linux/macOS: run `./exercises/verify/06-resource_files.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -79,9 +79,9 @@ And `Keywords` table like this:
 ```robot
 *** Keywords ***
 Verify That Error Page Is Visible
-    Page Should Contain    Error Page
-    Location Should Be    ${URL}/error.html
-    Title Should Be    Error Page
+    Get Text    body    contains    Error Page
+    Get Url    ==    ${URL}/error.html
+    Get Title    ==    Error Page
 
 Template Error Page Is Visible When Using Incorrect Credentials
     [Arguments]    ${username}    ${password}

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -4,9 +4,9 @@
     <summary>After the previous exercise our <code>invalid_login.robot</code>
     should look something like this</summary>
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 Resource    resource.robot
 
 *** Variables ***
@@ -19,7 +19,6 @@ Error Page Should Be Visible After Invalid Login With Empty And Space
     Enter Password    ${SPACE*2}
     Submit Login Form
     Verify That Error Page Is Visible
-    [Teardown]    Close Browser
 
 Error Page Should Be Visible After Invalid Login With Valid Username And Invalid Password
     Open Browser To Login Page
@@ -27,7 +26,6 @@ Error Page Should Be Visible After Invalid Login With Valid Username And Invalid
     Enter Password    asdsadsa
     Submit Login Form
     Verify That Error Page Is Visible
-    [Teardown]    Close Browser
 
 Error Page Should Be Visible After Invalid Login With Invalid Username And Valid Password
     Open Browser To Login Page
@@ -35,14 +33,13 @@ Error Page Should Be Visible After Invalid Login With Invalid Username And Valid
     Enter Password    ${PASSWORD}
     Submit Login Form
     Verify That Error Page Is Visible
-    [Teardown]    Close Browser
 
 *** Keywords ***
 
 Verify That Error Page Is Visible
-    Page Should Contain    Error Page
-    Location Should Be    ${URL}/error.html
-    Title Should Be    Error Page
+    Get Text    id=header    ==    Error Page
+    Get Url    ==    ${URL}/error.html
+    Get Title    ==    Error Page
 ```
 
 </details>
@@ -58,31 +55,29 @@ applicable when you need to run the same test, multiple times, every time with a
 Let's get started. Rename the first test case to `Template Error Page Is Visible When Using Incorrect Credentials`
 and move it from the `Test Cases` table under the `Keywords` table.
 
-Notice also that we have `[Teardown]` after every test separately. We can get rid of those by adding `Test Teardown`
-into our `Settings` table. Our `Template Error Page Is Visible When Using Incorrect Credentials` keyword also
-starts with `Open Browser to Login Page`, which is repeated in every test and it's not really part of the test. We
-can add a `Test Setup` into our `Settings` table as well. After making those changes we can delete those lines
-from `Template Error Page Is Visible When Using Incorrect Credentials`.
+Our `Template Error Page Is Visible When Using Incorrect Credentials` keyword starts with
+`Open Browser to Login Page`, which is repeated in every test and it's not really part of the test.
+We can get rid of the repetitive keyword by adding it as `Test Setup` into our `Settings` table.
+After that we can delete those the line from `Template Error Page Is Visible When Using Incorrect Credentials`.
+A similar addition could be done with teardowns and the `Test Teardown` setting.
 
 Also remember to add arguments for `Template Error Page Is Visible When Using Incorrect Credentials`.
 
-*Pro tip.* A keyword can take multiple arguments when separating them with 4 spaces.
+*Tip:* A keyword can take multiple arguments when separating them with 4 spaces.
 
 So now our `Settings` table should look like this:
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 Resource    resource.robot
 Test Setup    Open Browser To Login Page
-Test Teardown    Close Browser
 ```
 
 And `Keywords` table like this:
 
-```
+```robot
 *** Keywords ***
-
 Verify That Error Page Is Visible
     Page Should Contain    Error Page
     Location Should Be    ${URL}/error.html
@@ -96,7 +91,6 @@ Template Error Page Is Visible When Using Incorrect Credentials
     Verify That Error Page Is Visible
 ```
 
-
 Now we've prepared our suite to get ready for data driven tests. Let's add the final piece to the `Settings` table.
 http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#data-driven-style
 
@@ -107,20 +101,20 @@ We can then remove all of our existing test cases from `invalid_login.robot` tes
 
 Our `Settings` table should look like this:
 
-```
+```robot
 *** Settings ***
-Library    SeleniumLibrary
+Library    Browser
 Resource    resource.robot
 Test Setup    Open Browser To Login Page
-Test Teardown    Close Browser
 Test Template    Template Error Page Is Visible When Using Incorrect Credentials
 ```
 
 Let's create our very first data driven test case.
 
-So now that we're using the data driven style of creating test case, under test case table we can write `<name_of_the_test_case> <username> <password>`. Like this:
+So now that we're using the data driven style of creating test case, under test case table we can write
+`<name_of_the_test_case>    <username>    <password>`. Like this:
 
-```
+```robot
 *** Test Cases ***
 #test case name                  #username   #password
 Empty Username Empty Password    ${EMPTY}    ${EMPTY}
@@ -128,11 +122,12 @@ Empty Username Empty Password    ${EMPTY}    ${EMPTY}
 
 Now run `robot robot/invalid_login.robot` command to verify that changes are done correctly.
 
-Now let's create 4 more test cases. Just add new line <name of the test case> 4 spaces <username> 4 spaces <password> and voilá. We've now a new test case.
+Now let's create 4 more test cases. Just add new line `<name of the test case> 4 spaces <username> 4 spaces <password>`
+and voilá. We've now a new test case.
 
 Once you've implemented all 5 test cases run:
 
-  - Windows: double click the `07-test_template.cmd`
-  - Linux/macOS: run `./exercises/verify/07-test_template.sh`
+- Windows: double click the `07-test_template.cmd`
+- Linux/macOS: run `./exercises/verify/07-test_template.sh`
 
 If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -120,6 +120,9 @@ So now that we're using the data driven style of creating test case, under test 
 Empty Username Empty Password    ${EMPTY}    ${EMPTY}
 ```
 
+*Note:* the commented line (one starting with `#`) isn't required. It's there merely to server as a
+header for the test case table to enhance readability.
+
 Now run `robot robot/invalid_login.robot` command to verify that changes are done correctly.
 
 Now let's create 4 more test cases. Just add new line `<name of the test case> 4 spaces <username> 4 spaces <password>`

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -37,7 +37,7 @@ Error Page Should Be Visible After Invalid Login With Invalid Username And Valid
 *** Keywords ***
 
 Verify That Error Page Is Visible
-    Get Text    id=header    ==    Error Page
+    Get Text    body    contains    Error Page
     Get Url    ==    ${URL}/error.html
     Get Title    ==    Error Page
 ```

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -63,7 +63,7 @@ A similar addition could be done with teardowns and the `Test Teardown` setting.
 
 Also remember to add arguments for `Template Error Page Is Visible When Using Incorrect Credentials`.
 
-*Tip:* A keyword can take multiple arguments when separating them with 4 spaces.
+*Pro-tip:* A keyword can take multiple arguments when separating them with 4 spaces.
 
 So now our `Settings` table should look like this:
 

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -7,7 +7,7 @@
 ```robot
 *** Settings ***
 Library    Browser
-Resource    resource.robot
+Resource    common.resource
 
 *** Variables ***
 
@@ -70,7 +70,7 @@ So now our `Settings` table should look like this:
 ```robot
 *** Settings ***
 Library    Browser
-Resource    resource.robot
+Resource    common.resource
 Test Setup    Open Browser To Login Page
 ```
 
@@ -104,7 +104,7 @@ Our `Settings` table should look like this:
 ```robot
 *** Settings ***
 Library    Browser
-Resource    resource.robot
+Resource    common.resource
 Test Setup    Open Browser To Login Page
 Test Template    Template Error Page Is Visible When Using Incorrect Credentials
 ```

--- a/exercises/07-test_template.md
+++ b/exercises/07-test_template.md
@@ -45,7 +45,7 @@ Verify That Error Page Is Visible
 </details>
 
 So, basically what most of us did was copy-paste the first test several times, change the test names
-and change the entered user names and passwords. The tests do test different things and work well, but it
+and change the entered usernames and passwords. The tests do test different things and work well, but it
 doesn't really make sense to copy-paste several lines and modify 2 parameters. Instead, we should use
 test templates: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-templates
 
@@ -55,8 +55,8 @@ applicable when you need to run the same test, multiple times, every time with a
 Let's get started. Rename the first test case to `Template Error Page Is Visible When Using Incorrect Credentials`
 and move it from the `Test Cases` table under the `Keywords` table.
 
-Our `Template Error Page Is Visible When Using Incorrect Credentials` keyword starts with
-`Open Browser to Login Page`, which is repeated in every test and it's not really part of the test.
+The `Template Error Page Is Visible When Using Incorrect Credentials` keyword starts with a
+`Open Browser to Login Page`-keyword. This repeats in every test while it's not really part of the testing.
 We can get rid of the repetitive keyword by adding it as `Test Setup` into our `Settings` table.
 After that we can delete those the line from `Template Error Page Is Visible When Using Incorrect Credentials`.
 A similar addition could be done with teardowns and the `Test Teardown` setting.
@@ -123,11 +123,11 @@ Empty Username Empty Password    ${EMPTY}    ${EMPTY}
 Now run `robot robot/invalid_login.robot` command to verify that changes are done correctly.
 
 Now let's create 4 more test cases. Just add new line `<name of the test case> 4 spaces <username> 4 spaces <password>`
-and voilá. We've now a new test case.
+and voilà. We've now a new test case.
 
 Once you've implemented all 5 test cases run:
 
-- Windows: double click the `07-test_template.cmd`
+- Windows: double-click the `07-test_template.cmd`
 - Linux/macOS: run `./exercises/verify/07-test_template.sh`
 
-If you see `Ready to proceed!` then you're done for the exercise. Otherwise check the output and fix, rerun.
+If you see `Ready to proceed!` then you're done for the exercise. Otherwise, check the output and fix, rerun.

--- a/server/html/error.html
+++ b/server/html/error.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <div id="container">
-    <h1 id='header'>Error Page</h1>
+    <h1>Error Page</h1>
     <p>Login failed. Invalid user name and/or password.</p>
   </div>
 </body>

--- a/server/html/error.html
+++ b/server/html/error.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <div id="container">
-    <h1>Error Page</h1>
+    <h1 id='header'>Error Page</h1>
     <p>Login failed. Invalid user name and/or password.</p>
   </div>
 </body>

--- a/server/html/welcome.html
+++ b/server/html/welcome.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <div id='container'>
-  <h1>Welcome Page</h1>
+  <h1 id='header'>Welcome Page</h1>
   <p>Login succeeded. Now you can <a href=".">logout</a>.</p>
 </div>
 </body>

--- a/server/html/welcome.html
+++ b/server/html/welcome.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <div id='container'>
-  <h1 id='header'>Welcome Page</h1>
+  <h1>Welcome Page</h1>
   <p>Login succeeded. Now you can <a href=".">logout</a>.</p>
 </div>
 </body>

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -5,7 +5,7 @@ from static import LOGIN_ROBOT_FILE
 
 def check_file_exists():
     if not os.path.isfile(LOGIN_ROBOT_FILE):
-        print("login.robot not found under {}, please create one".format(LOGIN_ROBOT_FILE))
+        print(f"login.robot not found under {LOGIN_ROBOT_FILE}, please create one")
         sys.exit(1)
 
 def check_content():

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -9,7 +9,7 @@ def check_file_exists():
         sys.exit(1)
 
 def check_content():
-    is_open_browser = False
+    is_browser = False
     is_url = False
     is_password = False
     is_username = False
@@ -20,9 +20,9 @@ def check_content():
         data = f.readlines()
     for line in data:
         lowered_line = line.lower()
-        if "open browser" in lowered_line:
-            is_open_browser = True
-        elif re.search("localhost:7272", lowered_line):
+        if re.search(r"(new|open) (page|browser)", lowered_line):
+            is_browser = True
+        elif re.search(r"localhost:7272", lowered_line):
             is_url = True
         elif "username" in lowered_line:
             is_username = True
@@ -32,7 +32,7 @@ def check_content():
             is_login = True
         elif "welcome" in lowered_line:
             is_welcome = True
-    if is_open_browser and is_url and is_password and is_username and is_login and is_welcome:
+    if is_browser and is_url and is_password and is_username and is_login and is_welcome:
         print("Ready to proceed!")
     else:
         print("Not quite there yet! Did you remember browser, username, password or perhaps missing url? Did you verify your login succeeded?")

--- a/setup/02-robot_syntax.py
+++ b/setup/02-robot_syntax.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import subprocess
 from static import LOGIN_ROBOT_FILE
 

--- a/setup/02-robot_syntax_rule.py
+++ b/setup/02-robot_syntax_rule.py
@@ -37,19 +37,19 @@ class TestCaseImplementation02(TestRule):
             if not normalize(keyword) in test_steps:
                 report = True
         if report:
-            self.report(test, DEFAULT_MESSAGE + ", expected: {}".format(", ".join(MUST_KEYWORDS)), test.linenumber)
+            self.report(test, f"{DEFAULT_MESSAGE}, expected: {', '.join(MUST_KEYWORDS)}", test.linenumber)
 
         for keyword in test_steps:
             if normalize(keyword) in LOGIN_KEYWORDS:
                 break
         else:
-            self.report(test, DEFAULT_MESSAGE + ", expected one of: {}".format(", ".join(LOGIN_KEYWORDS)), test.linenumber)
+            self.report(test, f"{DEFAULT_MESSAGE}, expected one of: {', '.join(LOGIN_KEYWORDS)}", test.linenumber)
 
         for keyword in test_steps:
             if normalize(keyword) in VERIFY_KEYWORDS:
                 break
         else:
-            self.report(test, DEFAULT_MESSAGE + ", expected one of: {}".format(", ".join(VERIFY_KEYWORDS)), test.linenumber)
+            self.report(test, f"{DEFAULT_MESSAGE}, expected one of: {', '.join(VERIFY_KEYWORDS)}", test.linenumber)
 
 class TestCaseKeywordCases02(TestRule):
     severity = WARNING
@@ -59,7 +59,7 @@ class TestCaseKeywordCases02(TestRule):
         for step in test.steps:
             if len(step) > 1:
                 if step[1] != normalize(step[1]):
-                    self.report(test, "Best practice is to Capitalize All The Words In A Keyword: " + step[1] , test.linenumber)
+                    self.report(test, f"Best practice is to Capitalize All The Words In A Keyword: {step[1]}", test.linenumber)
 
 
 class CheckTestCasesName02(SuiteRule):
@@ -69,4 +69,4 @@ class CheckTestCasesName02(SuiteRule):
         expected_name = "Welcome Page Should Be Visible After Successful Login"
         for testcase in suite.testcases:
             if normalize(testcase.name) != expected_name:
-                self.report(suite, "Check test case name: {}, expected: {}".format(testcase.name, expected_name), 0)
+                self.report(suite, f"Check test case name: {testcase.name}, expected: {expected_name}", 0)

--- a/setup/02-robot_syntax_rule.py
+++ b/setup/02-robot_syntax_rule.py
@@ -2,26 +2,24 @@ from rflint.common import SuiteRule, TestRule, ERROR, WARNING
 from static import normalize
 
 MUST_KEYWORDS = [
-        "Open Browser",
-        "Input Text",
-        "Input Password"
-    ]
+    "New Browser",
+    "New Page",
+    "Fill Text",
+    "Fill Secret",
+]
 
 LOGIN_KEYWORDS = [
-        "Click Element",
-        "Click Button",
-        "Submit Form"
+    "Click",
+    "Keyboard Key",
 ]
 
 VERIFY_KEYWORDS = [
-        "Page Should Contain",
-        "Page Should Contain Element",
-        "Title Should Be",
-        "Wait Until Page Contains",
-        "Wait Until Page Contains Element"
+    "Get Title",
+    "Get Url",
+    "Get Text",
 ]
 
-DEFAULT_MESSAGE = "Did you find all keywords from SeleniumLibrary documentation?"
+DEFAULT_MESSAGE = "Did you find all keywords from the Browser-library documentation?"
 
 class TestCaseImplementation02(TestRule):
     severity = ERROR

--- a/setup/03-keywords_and_variables.py
+++ b/setup/03-keywords_and_variables.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import subprocess
 from static import LOGIN_ROBOT_FILE
 

--- a/setup/03-keywords_and_variables_rule.py
+++ b/setup/03-keywords_and_variables_rule.py
@@ -1,5 +1,4 @@
-from rflint.common import KeywordRule, SuiteRule, TestRule, GeneralRule, ERROR, WARNING
-from rflint.parser import SettingTable
+from rflint.common import KeywordRule, TestRule, GeneralRule, ERROR, WARNING
 from static import normalize
 
 ALLOWED_KEYWORDS = [

--- a/setup/03-keywords_and_variables_rule.py
+++ b/setup/03-keywords_and_variables_rule.py
@@ -22,7 +22,7 @@ class KeywordImplementation(KeywordRule):
     def apply(self, keyword):
         report = False
         if normalize(keyword.name) == ALLOWED_KEYWORDS[0]:
-            if not "${URL}" in keyword.steps[0][2].upper():
+            if not "${URL}" in keyword.steps[1][2].upper():
                 report = True
         if report:
             self.report(keyword, f"Do you have URL variable in place? Check keyword: {ALLOWED_KEYWORDS[0]}", keyword.linenumber+1)

--- a/setup/03-keywords_and_variables_rule.py
+++ b/setup/03-keywords_and_variables_rule.py
@@ -15,7 +15,7 @@ class InvalidKeywordName(KeywordRule):
 
     def apply(self, keyword):
         if not normalize(keyword.name) in ALLOWED_KEYWORDS:
-            self.report(keyword, "Keyword {} not allowed in {}".format(keyword.name, ", ".join(ALLOWED_KEYWORDS)), keyword.linenumber)
+            self.report(keyword, f"Keyword {keyword.name} not allowed in {', '.join(ALLOWED_KEYWORDS)}", keyword.linenumber)
 
 class KeywordImplementation(KeywordRule):
     severity = ERROR
@@ -26,14 +26,14 @@ class KeywordImplementation(KeywordRule):
             if not "${URL}" in keyword.steps[0][2].upper():
                 report = True
         if report:
-            self.report(keyword, "Do you have URL variable in place? Check keyword: {}".format(ALLOWED_KEYWORDS[0]), keyword.linenumber+1)
+            self.report(keyword, f"Do you have URL variable in place? Check keyword: {ALLOWED_KEYWORDS[0]}", keyword.linenumber+1)
 
 class KeywordsShouldStartWithCapitalLetter(KeywordRule):
     severity = WARNING
 
     def apply(self, keyword):
         if not keyword.name == normalize(keyword.name):
-            self.report(keyword, "Best practice is to Capitalize All The Words In A Keyword: " + keyword.name, keyword.linenumber)
+            self.report(keyword, f"Best practice is to Capitalize All The Words In A Keyword: {keyword.name}", keyword.linenumber)
 
 class GlobalVariablesShouldBeUpperCase(GeneralRule):
     severity = WARNING
@@ -42,7 +42,7 @@ class GlobalVariablesShouldBeUpperCase(GeneralRule):
         table = list(filter(lambda t: t.name.lower() == "variables", robot_file.tables))[0]
         for row in table.rows:
             if row.cells[0] != row.cells[0].upper():
-                self.report(robot_file, 'Variables in the "Variables" table should be UPPER CASE: ' + row.cells[0], row.linenumber)
+                self.report(robot_file, f"Variables in the \"Variables\" table should be UPPER CASE: {row.cells[0]}", row.linenumber)
 
 class TestCaseImplementation(TestRule):
     severity = ERROR
@@ -53,4 +53,4 @@ class TestCaseImplementation(TestRule):
             if len(step) > 1:
                 test_steps.append(normalize(step[1]))
         if test_steps != ALLOWED_KEYWORDS:
-            self.report(test, "Check that you've refactored test case {} in right manner, expected: {}".format(test.name, ", ".join(ALLOWED_KEYWORDS)), test.linenumber)
+            self.report(test, f"Check that you've refactored test case {test.name} in right manner, expected: {', '.join(ALLOWED_KEYWORDS)}", test.linenumber)

--- a/setup/04-setups_and_teardowns.args
+++ b/setup/04-setups_and_teardowns.args
@@ -1,5 +1,5 @@
 -A setup/common.args
 --rulefile setup/common_rules.py
 --configure NumberOfTestCases:2
---configure NumberOfKeywordsInTestSuite:7
+--configure NumberOfKeywordsInTestSuite:8
 --rulefile setup/04-setups_and_teardowns_rule.py

--- a/setup/04-setups_and_teardowns.py
+++ b/setup/04-setups_and_teardowns.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import subprocess
 from static import LOGIN_ROBOT_FILE
 

--- a/setup/04-setups_and_teardowns_rule.py
+++ b/setup/04-setups_and_teardowns_rule.py
@@ -1,8 +1,8 @@
 from rflint.common import TestRule, ERROR
 from static import normalize
 
-CLOSE_BROWSER = "Close Browser"
 SUCCESSFUL_LOGIN = "Do Successful Login"
+SUCCESSFUL_LOGOUT = "Do Successful Logout"
 
 class TestSettingsCheck(TestRule):
     severity = ERROR
@@ -14,6 +14,7 @@ class TestSettingsCheck(TestRule):
         for setting in test.settings:
             settings.append(normalize(setting[2]))
         if normalize(test.name) == "Welcome Page Should Be Visible After Successful Login":
+            expected_settings.append(SUCCESSFUL_LOGOUT)
             if SUCCESSFUL_LOGIN in settings:
                 report = False
         elif normalize(test.name) == "Login Form Should Be Visible After Successful Logout":

--- a/setup/04-setups_and_teardowns_rule.py
+++ b/setup/04-setups_and_teardowns_rule.py
@@ -1,4 +1,4 @@
-from rflint.common import KeywordRule, SuiteRule, TestRule, ERROR
+from rflint.common import TestRule, ERROR
 from static import normalize
 
 CLOSE_BROWSER = "Close Browser"

--- a/setup/04-setups_and_teardowns_rule.py
+++ b/setup/04-setups_and_teardowns_rule.py
@@ -21,4 +21,4 @@ class TestSettingsCheck(TestRule):
             if SUCCESSFUL_LOGIN in settings and CLOSE_BROWSER in settings:
                 report = False
         if report:
-            self.report(test, "Check out that you've added needed setup and/or teardown for your test: {}, expected: {}".format(test.name, ", ".join(expected_settings)), test.linenumber)
+            self.report(test, f"Check out that you've added needed setup and/or teardown for your test: {test.name}, expected: {', '.join(expected_settings)}", test.linenumber)

--- a/setup/04-setups_and_teardowns_rule.py
+++ b/setup/04-setups_and_teardowns_rule.py
@@ -10,15 +10,14 @@ class TestSettingsCheck(TestRule):
     def apply(self, test):
         report = True
         settings = []
-        expected_settings = [CLOSE_BROWSER]
+        expected_settings = [SUCCESSFUL_LOGIN]
         for setting in test.settings:
             settings.append(normalize(setting[2]))
         if normalize(test.name) == "Welcome Page Should Be Visible After Successful Login":
-            if CLOSE_BROWSER in settings:
+            if SUCCESSFUL_LOGIN in settings:
                 report = False
         elif normalize(test.name) == "Login Form Should Be Visible After Successful Logout":
-            expected_settings.append(SUCCESSFUL_LOGIN)
-            if SUCCESSFUL_LOGIN in settings and CLOSE_BROWSER in settings:
+            if SUCCESSFUL_LOGIN in settings:
                 report = False
         if report:
             self.report(test, f"Check out that you've added needed setup and/or teardown for your test: {test.name}, expected: {', '.join(expected_settings)}", test.linenumber)

--- a/setup/05-negative_testing_rule.py
+++ b/setup/05-negative_testing_rule.py
@@ -1,4 +1,4 @@
-from rflint.common import KeywordRule, SuiteRule, TestRule, ERROR
+from rflint.common import KeywordRule, TestRule, ERROR
 from static import normalize
 
 MUST_KEYWORDS = [

--- a/setup/05-negative_testing_rule.py
+++ b/setup/05-negative_testing_rule.py
@@ -38,7 +38,7 @@ class TestCaseImplementation05(TestRule):
             has_failures = True
         elif len(test_steps) == 4:
             has_setup = False
-            setup = list(filter(lambda s: "test setup" in str(s).lower(), test.parent.settings))[0]
+            setup = next(filter(lambda s: "test setup" in str(s).lower(), test.parent.settings), "")
             if SETUP_KEYWORD in normalize(str(setup)) and not setup.is_comment():
                 has_setup = True
             if not has_setup:

--- a/setup/05-negative_testing_rule.py
+++ b/setup/05-negative_testing_rule.py
@@ -27,8 +27,8 @@ class TestCaseImplementation05(TestRule):
     severity = ERROR
 
     def apply(self, test):
-        default_message = "Check that you've implemented test case {} as instructed: ".format(test.name)
-        default_message += "{} is expected as a setup or part of the test. {} are required as part of the test".format(SETUP_KEYWORD, ", ".join(MUST_KEYWORDS))
+        default_message = f"Check that you've implemented test case {test.name} as instructed: "
+        default_message += f"{SETUP_KEYWORD} is expected as a setup or part of the test. {', '.join(MUST_KEYWORDS)} are required as part of the test"
         test_steps = []
         for step in test.steps:
             if len(step) > 1:

--- a/setup/06-resource_files.py
+++ b/setup/06-resource_files.py
@@ -3,12 +3,12 @@ import sys
 import subprocess
 from static import ROBOT_ROOT_PATH, INVALID_LOGIN_ROBOT, LOGIN_ROBOT_FILE
 
-RESOURCE_FILE = os.path.join(ROBOT_ROOT_PATH,'resource.robot')
+RESOURCE_FILE = os.path.join(ROBOT_ROOT_PATH, "common.resource")
 
 
 def check_file_exists():
     if not os.path.isfile(RESOURCE_FILE):
-        print("resource.robot not found under {}, please create one".format(RESOURCE_FILE))
+        print(f"common.resource not found under {RESOURCE_FILE}, please create one")
         sys.exit(1)
 
 def run_linting():

--- a/setup/06-resource_files_rule.py
+++ b/setup/06-resource_files_rule.py
@@ -19,7 +19,7 @@ class NumberOfKeywordsInSuite06(SuiteRule):
         report = False
         for keyword in suite.keywords:
             keywords.append(keyword.name)
-        if suite.name == "login" and len(keywords) != 3:
+        if suite.name == "login" and len(keywords) != 4:
             report = True
         elif suite.name == "invalid_login" and len(keywords) != 1:
             report = True
@@ -39,7 +39,7 @@ class NumberOfKeywordsInResource06(ResourceRule):
         for keyword in resource.keywords:
             keywords.append(keyword.name.lower().title())
         if keywords != self.ALLOWED_KEYWORDS:
-            self.report(resource, f"Did you remember to add all keywords: {', '.join(self.ALLOWED_KEYWORDS)} to resources.robot file?", 0)
+            self.report(resource, f"Did you remember to add all keywords: {', '.join(self.ALLOWED_KEYWORDS)} to common.resource file?", 0)
 
 class NumberOfTestCasesInSuite06(SuiteRule):
     severity = ERROR

--- a/setup/06-resource_files_rule.py
+++ b/setup/06-resource_files_rule.py
@@ -39,7 +39,7 @@ class NumberOfKeywordsInResource06(ResourceRule):
         for keyword in resource.keywords:
             keywords.append(keyword.name.lower().title())
         if keywords != self.ALLOWED_KEYWORDS:
-            self.report(resource, "Did you remember to add all keywords: {} to resources.robot file?".format(", ".join(self.ALLOWED_KEYWORDS)), 0)
+            self.report(resource, f"Did you remember to add all keywords: {', '.join(self.ALLOWED_KEYWORDS)} to resources.robot file?", 0)
 
 class NumberOfTestCasesInSuite06(SuiteRule):
     severity = ERROR
@@ -52,4 +52,3 @@ class NumberOfTestCasesInSuite06(SuiteRule):
             self.report(suite, "Do you have the existing 2 cases in login.robot?", 0)
         elif suite.name == "invalid_login" and len(tests) != 3:
             self.report(suite, "Did you implement 2 more tests to invalid_login.robot?", 0)
-

--- a/setup/07-test_template.py
+++ b/setup/07-test_template.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import subprocess
 from static import INVALID_LOGIN_ROBOT

--- a/setup/07-test_template_rule.py
+++ b/setup/07-test_template_rule.py
@@ -1,4 +1,4 @@
-from rflint.common import KeywordRule, SuiteRule, TestRule, ERROR
+from rflint.common import KeywordRule, SuiteRule, ERROR
 
 from static import normalize
 
@@ -9,7 +9,6 @@ ALLOWED_KEYWORDS = [
 
 class TestTemplateInUse(SuiteRule):
     severity = ERROR
-
 
     def apply(self, suite):
         is_test_template = False

--- a/setup/07-test_template_rule.py
+++ b/setup/07-test_template_rule.py
@@ -16,8 +16,8 @@ class TestTemplateInUse(SuiteRule):
         for setting in suite.settings:
             if setting[0].lower() == "test template":
                 is_test_template = True
-                if normalize(setting[1])  != ALLOWED_KEYWORDS[0]:
-                    self.report(suite, "Did you add correct keyword for test template?, expected: {}".format(ALLOWED_KEYWORDS[1]), 0)
+                if normalize(setting[1]) != ALLOWED_KEYWORDS[0]:
+                    self.report(suite, f"Did you add correct keyword for test template?, expected: {ALLOWED_KEYWORDS[1]}", 0)
         if not is_test_template:
             self.report(suite, "Did you remember to add Test Template option?", 0)
 
@@ -29,7 +29,7 @@ class KeywordNamesIn07(SuiteRule):
         for keyword in suite.keywords:
             keywords.append(keyword.name)
         if sorted(keywords) != ALLOWED_KEYWORDS:
-            self.report(suite, "Did you implement all keywords?, expected: {}".format(", ".join(ALLOWED_KEYWORDS)), 0)
+            self.report(suite, f"Did you implement all keywords?, expected: {', '.join(ALLOWED_KEYWORDS)}", 0)
 
 class TestTemplateImplementation(KeywordRule):
     severity = ERROR
@@ -48,4 +48,4 @@ class TestTemplateImplementation(KeywordRule):
                 if len(step) > 1:
                     steps.append(normalize(step[1]))
             if steps != self.ALLOWED_TEMPLATE_STEPS:
-                self.report(keyword, "Did you implement all needed steps for template?, expected: {}".format(", ".join(self.ALLOWED_TEMPLATE_STEPS)), keyword.linenumber)
+                self.report(keyword, f"Did you implement all needed steps for template?, expected: {', '.join(self.ALLOWED_TEMPLATE_STEPS)}", keyword.linenumber)

--- a/setup/common_rules.py
+++ b/setup/common_rules.py
@@ -1,5 +1,4 @@
 from rflint.common import SuiteRule, ERROR
-from rflint.parser import SettingTable
 
 class NumberOfTestCases(SuiteRule):
 

--- a/setup/common_rules.py
+++ b/setup/common_rules.py
@@ -14,7 +14,7 @@ class NumberOfTestCases(SuiteRule):
         for testcase in suite.testcases:
             test_cases.append(testcase.name)
         if len(test_cases) != self.max_test_cases:
-            self.report(suite, "Check that you've implemented all test cases instructed in exercise, expected: {}".format(self.max_test_cases), 0)
+            self.report(suite, f"Check that you've implemented all test cases instructed in exercise, expected: {self.max_test_cases}", 0)
 
 class NumberOfKeywordsInTestSuite(SuiteRule):
     severity = ERROR
@@ -28,4 +28,4 @@ class NumberOfKeywordsInTestSuite(SuiteRule):
         for keyword in suite.keywords:
             self.keyword_names.append(keyword.name)
         if len(self.keyword_names) != self.max_keywords:
-            self.report(suite, "Check that you've implemented all keywords from exercise, expected: {}".format(self.max_keywords), 0)
+            self.report(suite, f"Check that you've implemented all keywords from exercise, expected: {self.max_keywords}", 0)

--- a/setup/verify_env.py
+++ b/setup/verify_env.py
@@ -25,8 +25,8 @@ def check_robot_framework_package():
 
 def check_selenium_library_package():
     pip_packages = get_pip_packages()
-    if not "robotframework-seleniumlibrary" in pip_packages:
-        print("Install SeleniumLibrary: pip install robotframework-seleniumlibrary")
+    if not "robotframework-browser" in pip_packages:
+        print("Install Browser-library: pip install robotframework-browser")
         sys.exit(1)
 
 def check_rflint_package():
@@ -44,17 +44,12 @@ def check_smoke_suite_location():
 
 def evaluate_environment():
     try:
-        subprocess.run(["robot", "-v", "BROWSER:ff", "-d", str(SETUP_DIRECTORY), SMOKE_TEST_SUITE], check=True)
-        IS_FIREFOX = True
+        subprocess.run(["robot", "-d", str(SETUP_DIRECTORY), SMOKE_TEST_SUITE], check=True)
+        BROWSERS_INSTALLED = True
     except subprocess.CalledProcessError:
-        IS_FIREFOX = False
-    try:
-        subprocess.run(["robot", "-v", "BROWSER:gc", "-d", str(SETUP_DIRECTORY), SMOKE_TEST_SUITE], check=True)
-        IS_CHROME = True
-    except subprocess.CalledProcessError:
-        IS_CHROME = False
-    if not IS_CHROME and not IS_FIREFOX:
-        print("Setup webdriver based on the instructions for Firefox OR Chrome")
+        BROWSERS_INSTALLED = False
+    if not BROWSERS_INSTALLED:
+        print("No browser binaries installed. Install them according to the instructions.")
         sys.exit(1)
 
 

--- a/setup/verify_setup.robot
+++ b/setup/verify_setup.robot
@@ -1,11 +1,7 @@
 *** Settings ***
-Library    SeleniumLibrary
-
+Library    Browser
 
 *** Test Cases ***
-
 Test Open Browser
-    Open Browser    http://localhost:7272    browser=${BROWSER}
-    Sleep    10s
-    Title Should Be     Login Page
-    [Teardown]    Close All Browsers
+    New Page    http://localhost:7272
+    Get Title    ==     Login Page


### PR DESCRIPTION
All traces of SeleniumLibrary are removed and the training now focues solely on Browser.

The main structure stays the same, excluding the removal of Teardown from the code. I figured that there's nothing to tear down as Browser closes browsers automatically. The concept is still explained alongside setup.

The markdown documents are also cleared up a bit and some other minor changes.