### PR TITLE
Improve manual testing check

### DIFF
--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import re
-from setup.static import LOGIN_ROBOT_FILE
+from setup.static import LOGIN_ROBOT_FILE, check_running_in_root
+
 
 def check_file_exists():
     if not os.path.isfile(LOGIN_ROBOT_FILE):
@@ -57,6 +58,7 @@ def check_content():
         sys.exit(1)
 
 def main():
+    check_running_in_root()
     check_file_exists()
     check_content()
 

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -52,7 +52,8 @@ def check_content():
     if is_browser and is_url and is_password and is_username and is_login and is_welcome:
         print("✅  Ready to proceed!")
     else:
-        print("❌  Not quite there yet! Did you remember browser, username, password or perhaps missing url? Did you verify your login succeeded?")
+        print("❌  Not quite there yet! Did you remember browser, username, password or perhaps missing url? Did you "
+              "verify your login succeeded and took you to the welcome page?")
         sys.exit(1)
 
 def main():

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -5,8 +5,11 @@ from setup.static import LOGIN_ROBOT_FILE
 
 def check_file_exists():
     if not os.path.isfile(LOGIN_ROBOT_FILE):
-        print(f"login.robot not found under {LOGIN_ROBOT_FILE}, please create one")
+        print(f"❌  Hmm. I don't see your 'login.robot' file. I was expecting to see it at '{LOGIN_ROBOT_FILE}'")
+        print("Double-check that it's in the right place and named correctly and try again.")
         sys.exit(1)
+    else:
+        print("✔️ Found your 'login.robot' file.")
 
 def check_content():
     is_browser = False

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -35,10 +35,24 @@ def check_content():
             is_login = True
         elif "welcome" in lowered_line:
             is_welcome = True
+
+    if is_browser:
+        print("✔️ Found open browser step.")
+    if is_url:
+        print("✔️ Found specific URL in steps.")
+    if is_username:
+        print("✔️ Found mention of username field in steps.")
+    if is_password:
+        print("✔️ Found mention of password field in steps.")
+    if is_login:
+        print("✔️ Found login step.")
+    if is_welcome:
+        print("✔️ Found welcome page step.")
+
     if is_browser and is_url and is_password and is_username and is_login and is_welcome:
-        print("Ready to proceed!")
+        print("✅  Ready to proceed!")
     else:
-        print("Not quite there yet! Did you remember browser, username, password or perhaps missing url? Did you verify your login succeeded?")
+        print("❌  Not quite there yet! Did you remember browser, username, password or perhaps missing url? Did you verify your login succeeded?")
         sys.exit(1)
 
 def main():

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -23,7 +23,7 @@ def check_content():
         data = f.readlines()
     for line in data:
         lowered_line = line.lower()
-        if re.search(r"(new|open) (page|browser)", lowered_line):
+        if re.search(r"(new|open).+(page|browser|app)", lowered_line):
             is_browser = True
         if re.search(r"localhost:7272", lowered_line):
             is_url = True

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -31,7 +31,7 @@ def check_content():
             is_username = True
         if "password" in lowered_line:
             is_password = True
-        if "click" in lowered_line or "login" in lowered_line:
+        if re.search("(log ?in)|button", lowered_line):
             is_login = True
         if "welcome" in lowered_line:
             is_welcome = True

--- a/setup/01-manual_testing.py
+++ b/setup/01-manual_testing.py
@@ -25,15 +25,15 @@ def check_content():
         lowered_line = line.lower()
         if re.search(r"(new|open) (page|browser)", lowered_line):
             is_browser = True
-        elif re.search(r"localhost:7272", lowered_line):
+        if re.search(r"localhost:7272", lowered_line):
             is_url = True
-        elif "username" in lowered_line:
+        if "username" in lowered_line:
             is_username = True
-        elif "password" in lowered_line:
+        if "password" in lowered_line:
             is_password = True
-        elif "click" in lowered_line or "login" in lowered_line:
+        if "click" in lowered_line or "login" in lowered_line:
             is_login = True
-        elif "welcome" in lowered_line:
+        if "welcome" in lowered_line:
             is_welcome = True
 
     if is_browser:

--- a/setup/static.py
+++ b/setup/static.py
@@ -1,4 +1,6 @@
 import os
+import sys
+
 ROBOT_ROOT_PATH = os.path.abspath(os.path.join(".", "robot"))
 LOGIN_ROBOT_FILE = os.path.abspath(os.path.join(ROBOT_ROOT_PATH, "login.robot"))
 INVALID_LOGIN_ROBOT = os.path.abspath(os.path.join(ROBOT_ROOT_PATH, "invalid_login.robot"))
@@ -8,5 +10,20 @@ if "PYTHONPATH" in CURRENT_ENV:
 else:
     CURRENT_ENV["PYTHONPATH"] = f"setup{os.pathsep}"
 
+
 def normalize(keyword):
     return keyword.strip().title()
+
+
+def check_running_in_root():
+    current_folder = os.getcwd()
+    supposed_exercises_folder = os.path.abspath(os.path.join(current_folder, "exercises"))
+    supposed_setup_folder = os.path.abspath(os.path.join(current_folder, "setup"))
+
+    in_root = os.path.isdir(supposed_exercises_folder) and os.path.isdir(supposed_setup_folder)
+    if not in_root:
+        print(f"🚩 Hmm. It looks like the script is running in '{current_folder}' instead of the repo root folder.")
+        print("For the verification to work correctly, you need to run the script from the root of the repository ("
+              "probably named 'rf-katas').")
+        print("Try again, but double-check that you're running the verify script from the repository root.")
+        sys.exit(1)


### PR DESCRIPTION
We discussed improving the check a bit in #28.

Previously, myself and other users found that it was difficult to know what we had done wrong.

# Intent
I hope that these changes 
- make it easier for people to know what they're missing
- make the check specific to general _actions_ and **less specific to** 
    - ordering of words
    - specific words
    - combination or separation of steps
# Test Cases
I've checked it against the following sets of manual steps:

```
Open the app by going to localhost:7272
Fill in the username
Fill in the password
Click the login button
Check you're on the Welcome page
```

```
Open the browser to http://localhost:7272
Put in the username and password
Log in and check that you're on the Welcome page
```

```
Open browser to localhost:7272
Enter "demo" in username field
Enter "mode" in password field
Click the login button
Check that you're taken to the welcome page
Check that you can log out
Try entering bad credentials
Ensure that when you do, you see an error page
```

```
Open browser
Navigate to localhost:7272
Enter username
Enter password
Submit login form
Check that welcome page text is visible
```

Any feedback is welcome!